### PR TITLE
Hardware encoding and Latency minimization via FFMPEG

### DIFF
--- a/code/common/src/PVRGlobals.cpp
+++ b/code/common/src/PVRGlobals.cpp
@@ -47,6 +47,10 @@ void pvrdebug(string msg)
 	GetLocalTime(&t);
 	ofstream of(std::wstring(_GetExePath() + logFileDebug).c_str(), ios_base::app);
 	auto ms = system_clock::now().time_since_epoch() / 1ms;
+
+	//std::replace(msg.begin(), msg.end(), '\n', ' ');
+	std::replace(msg.begin(), msg.end(), '\r', ' ');
+
 	string elapsed = (ms - pvrdebug_oldMs < 1000 ? to_string(ms - pvrdebug_oldMs) : "max");
 	of << t.wMinute << ":" << setfill('0') << setw(2) << t.wSecond << " " << setfill('0') << setw(3) << elapsed << "  " << msg << endl;
 	

--- a/code/common/src/PVRGlobals.h
+++ b/code/common/src/PVRGlobals.h
@@ -67,13 +67,13 @@ void pvrInfo(T i) {
 void pvrdebugClear();
 
 // PVR_DB only to Debug Log file, PVR_DB_I both to Log file and Info file
-#if defined _DEBUG
+#if defined PVR_DEBUG
 	#define PVR_DB(msg) pvrdebug(msg)
 #else
 	#define PVR_DB(msg)
 #endif
 
-#if defined _DEBUG
+#if defined PVR_DEBUG
     #define PVR_DB_I(msg) {pvrdebug(msg);pvrInfo(msg);}
 #else
 	#define PVR_DB_I(msg) pvrInfo(msg);

--- a/code/windows/PhoneVR/AMP Crashes WorkArround.txt
+++ b/code/windows/PhoneVR/AMP Crashes WorkArround.txt
@@ -1,0 +1,5 @@
+in Debug Build,
+
+Replace _DEBUG preProcessor with NDEBUG & PVR_DEBUG
+
+Code Generation RuntimeLibrary -> MultiThreaded DLL (/MD) (initially was /MDd)

--- a/code/windows/PhoneVR/PhoneVR.sln
+++ b/code/windows/PhoneVR/PhoneVR.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PhoneVR", "PhoneVR\PhoneVR.vcxproj", "{EECAFA17-E17D-4D6A-898F-DA593C98D0E2}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "driver_PVRServer", "PhoneVR\PhoneVR.vcxproj", "{EECAFA17-E17D-4D6A-898F-DA593C98D0E2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,7 +14,6 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EECAFA17-E17D-4D6A-898F-DA593C98D0E2}.Debug|x64.ActiveCfg = Debug|x64
-		{EECAFA17-E17D-4D6A-898F-DA593C98D0E2}.Debug|x64.Build.0 = Debug|x64
 		{EECAFA17-E17D-4D6A-898F-DA593C98D0E2}.Debug|x86.ActiveCfg = Debug|Win32
 		{EECAFA17-E17D-4D6A-898F-DA593C98D0E2}.Debug|x86.Build.0 = Debug|Win32
 		{EECAFA17-E17D-4D6A-898F-DA593C98D0E2}.Release|x64.ActiveCfg = Release|x64
@@ -24,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {019DA038-36FE-4F25-AAF0-53EFA125B5D8}
 	EndGlobalSection
 EndGlobal

--- a/code/windows/PhoneVR/PhoneVR/PVRGraphics.cpp
+++ b/code/windows/PhoneVR/PhoneVR/PVRGraphics.cpp
@@ -1,24 +1,5 @@
 #include "PVRGraphics.h"
 
-#include <d3d11.h>
-
-#include <amp_graphics.h>
-#include "PVRGlobals.h"
-#include <optional>
-
-
-#pragma comment(lib, "d3d11.lib")
-#pragma comment(lib, "dxgi.lib")
-#pragma comment(lib, "d3dcompiler.lib")
-
-
-using namespace std;
-using namespace this_thread;
-using namespace concurrency;
-using namespace concurrency::direct3d;
-using namespace concurrency::graphics;
-using namespace concurrency::graphics::direct3d;
-
 namespace {
 	ID3D11Device *dxDev;
 	ID3D11DeviceContext *dxDevCtx;
@@ -37,21 +18,6 @@ namespace {
 	bool gRunning = false;
 	thread *gThr;
 }
-
-#define RELEASE(obj) if(obj) { obj->Release(); obj = nullptr; }
-#define OK_OR_EXEC(call, func) if(FAILED(call)) func()
-#define OK_OR_DEBUG(call) { HRESULT hr = call; OK_OR_EXEC(hr, [hr] { PVR_DB_I("######### DirectX Error: #########"); debugHr(hr); }); }
-#define QUERY(from, to) OK_OR_DEBUG(from->QueryInterface(__uuidof(to), reinterpret_cast<void**>(&to)))
-//#define PARENT(child, parent) OK_OR_DEBUG(child->GetParent(__uuidof(parent), reinterpret_cast<void**>(&parent)))
-//#define OK_OR_REINIT(call) OK_OR_EXEC(call, [] { PVRReleaseDX(); PVRInitDX(outID); })
-
-// RGB to YUV constants
-#define wr 0.299f
-#define wb 0.114f
-#define wg 0.587f // 1.0 - wr - wb;
-#define ku 0.492f //0.436 / (1.0 - wb);
-#define kv 0.877f //0.615 / (1.0 - wr);
-
 
 void PVRInitDX() {
 	auto fl = D3D_FEATURE_LEVEL_11_0;
@@ -72,7 +38,8 @@ void PVRUpdTexHdl(uint64_t texHdl, int whichBuf) {
 
 void PVRStartGraphics(vector<vector<uint8_t *>> vvbuf, uint32_t inpWidth, uint32_t inpHeight) {
 	gRunning = true;
-	gThr = new thread([=] {
+	gThr = new std::thread([=] {
+
 		vector<vector<array_view<uint, 2>>> yuvBufViews;   // output
 
 		for (auto vbuf : vvbuf) // divide width by 4: store 4 bytes in an uint

--- a/code/windows/PhoneVR/PhoneVR/PVRGraphics.h
+++ b/code/windows/PhoneVR/PhoneVR/PVRGraphics.h
@@ -1,5 +1,37 @@
 #pragma once
 #include <vector>
+#include <d3d11.h>
+
+#include <amp_graphics.h>
+#include "PVRGlobals.h"
+#include <optional>
+
+
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "d3dcompiler.lib")
+
+
+using namespace std;
+using namespace this_thread;
+using namespace concurrency;
+using namespace concurrency::direct3d;
+using namespace concurrency::graphics;
+using namespace concurrency::graphics::direct3d;
+
+#define RELEASE(obj) if(obj) { obj->Release(); obj = nullptr; }
+#define OK_OR_EXEC(call, func) if(FAILED(call)) func()
+#define OK_OR_DEBUG(call) { HRESULT hr = call; OK_OR_EXEC(hr, [hr] { PVR_DB_I("######### DirectX Error: #########"); debugHr(hr); }); }
+#define QUERY(from, to) OK_OR_DEBUG(from->QueryInterface(__uuidof(to), reinterpret_cast<void**>(&to)))
+//#define PARENT(child, parent) OK_OR_DEBUG(child->GetParent(__uuidof(parent), reinterpret_cast<void**>(&parent)))
+//#define OK_OR_REINIT(call) OK_OR_EXEC(call, [] { PVRReleaseDX(); PVRInitDX(outID); })
+
+// RGB to YUV constants
+#define wr 0.299f
+#define wb 0.114f
+#define wg 0.587f // 1.0 - wr - wb;
+#define ku 0.492f //0.436 / (1.0 - wb);
+#define kv 0.877f //0.615 / (1.0 - wr);
 
 void PVRInitDX();
 void PVRUpdTexHdl(uint64_t texHdl, int whichBuffer);

--- a/code/windows/PhoneVR/PhoneVR/PVRSockets.h
+++ b/code/windows/PhoneVR/PhoneVR/PVRSockets.h
@@ -6,11 +6,13 @@
 #include "PVRGlobals.h"
 #include "PVRSocketUtils.h"
 
+#include "PVRffmpeg.h"
+
 void PVRStartConnectionListener(std::function<void(std::string ip, PVR_MSG devType)> callback);
 void PVRStopConnectionListener();
 
 void PVRStartStreamer(std::string ip, uint16_t width, uint16_t height, std::function<void(std::vector<uint8_t>)> headerCb, std::function<void()> onErrCb);
-void PVRProcessFrame(uint64_t hdl, Eigen::Quaternionf quat);
+void PVRProcessFrame(PVRffmpeg *ff, SharedTextureHandle_t hdl, Eigen::Quaternionf quat);
 void PVRStopStreamer();
 
 void PVRStartReceiveData(std::string ip, vr::DriverPose_t *pose, uint32_t *objId);

--- a/code/windows/PhoneVR/PhoneVR/PVRffmpeg.cpp
+++ b/code/windows/PhoneVR/PhoneVR/PVRffmpeg.cpp
@@ -1,0 +1,350 @@
+#include "PVRffmpeg.h"
+
+void ffmpeg_log_callback(void* classptr, int LogLevel, const char* printfString, va_list args)
+{
+	char buffer[256];
+	buffer[0] = '\0';
+
+	vsprintf(buffer, printfString, args);
+	PVR_DB("FFMPEG LOG: " + string(buffer));
+}
+
+PVRffmpeg::PVRffmpeg()
+{
+	av_log_set_flags(AV_LOG_INFO); 
+	av_log_set_callback(&ffmpeg_log_callback);
+
+	/* Calling SetDllDirectory with the empty string (but not NULL) removes the
+	 * current working directory from the DLL search path as a security pre-caution. */
+	//SetDllDirectory(L"");
+
+	avdevice_register_all();
+	avformat_network_init();
+}
+
+PVRffmpeg::~PVRffmpeg()
+{
+	avformat_network_deinit();
+}
+
+void PVRffmpeg::setSettings(int width, int height, string remoteIP, int port)
+{
+	this->width = width;
+	this->height = height;
+	this->remoteIP = remoteIP;
+	this->remotePort = port;	
+	//AVCodec *avc = avcodec_find_encoder_by_name("H264");
+}
+
+extern "C"
+{
+#include "libavutil/pixdesc.h"
+#include "libavutil/imgutils.h"
+}
+
+void PVRffmpeg::ProcessSharedHandle(SharedTextureHandle_t igfxSharedHandle, Quaternionf iquat)
+{
+	mgfxSharedHandle.lock();
+
+	gfxSharedHandle = igfxSharedHandle;
+	quat = iquat;
+	
+	if (OutputEncoderContext)
+	{
+		AVPacket *pkt = av_packet_alloc();
+		if (!pkt)
+		{
+			PVR_DB("PVRffmpeg::ProcessSharedHandle() Could not allocate pkt");
+			//exit(1);
+		}
+
+		AVFrame* frame = av_frame_alloc();
+		if (!frame) {
+			PVR_DB("PVRffmpeg::ProcessSharedHandle() Could not allocate video frame");
+			//exit(1);
+		}
+		frame->format = OutputEncoderContext->pix_fmt;
+		frame->width = OutputEncoderContext->width;
+		frame->height = OutputEncoderContext->height;
+		
+		//int ret = av_frame_get_buffer(frame, 0);
+		/*int align = 0;
+
+		const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get((AVPixelFormat)frame->format);
+		int ret, i, padded_height, total_size;
+		int plane_padding = 32;
+		ptrdiff_t linesizes[4];
+		size_t sizes[4];
+
+		if (!desc)
+		{
+			PVR_DB("av_pix_fmt_desc_get failed : " + to_string(  AVERROR(EINVAL) ) );
+		}
+
+		if ((ret = av_image_check_size(frame->width, frame->height, 0, NULL)) < 0)
+		{
+			PVR_DB("av_image_check_size failed : " + to_string(ret));
+		}
+
+		if (!frame->linesize[0]) {
+			if (align <= 0)
+				align = 32;
+
+			for (i = 1; i <= align; i += i) {
+				ret = av_image_fill_linesizes(frame->linesize, (AVPixelFormat)frame->format,
+					FFALIGN(frame->width, i));
+				if (ret < 0)
+				{
+					PVR_DB("av_image_fill_linesizes failed : " + to_string(ret));
+				}
+				if (!(frame->linesize[0] & (align - 1)))
+					break;
+			}
+
+			for (i = 0; i < 4 && frame->linesize[i]; i++)
+				frame->linesize[i] = FFALIGN(frame->linesize[i], align);
+		}
+
+		for (i = 0; i < 4; i++)
+			linesizes[i] = frame->linesize[i];
+
+		padded_height = FFALIGN(frame->height, 32);
+		if ((ret = av_image_fill_plane_sizes(sizes, (AVPixelFormat)frame->format,
+			padded_height, linesizes)) < 0)
+		{
+			PVR_DB("av_image_fill_plane_sizes failed : " + to_string(ret));
+		}
+
+		total_size = 4 * plane_padding;
+		for (i = 0; i < 4; i++) {
+			if (sizes[i] > INT_MAX - total_size)
+			{
+				PVR_DB("total_size plane_padding failed : " + to_string(AVERROR(EINVAL)));
+			}
+			total_size += sizes[i];
+		}
+
+		frame->buf[0] = av_buffer_alloc(total_size);
+		if (!frame->buf[0]) {
+			ret = AVERROR(ENOMEM);
+			goto fail;
+		}
+
+		if ((ret = av_image_fill_pointers(frame->data, (AVPixelFormat)frame->format, padded_height,
+			frame->buf[0]->data, frame->linesize)) < 0)
+			goto fail;
+
+		for (i = 1; i < 4; i++) {
+			if (frame->data[i])
+				frame->data[i] += i * plane_padding;
+		}
+
+		frame->extended_data = frame->data;	
+
+		if (ret < 0) {
+			char errbuf[124];
+
+			av_strerror(AVERROR(ret), errbuf, 124);
+			PVR_DB("PVRffmpeg::Stream() Could not allocate the frame data Error (" + to_string(ret) + "): " + errbuf );
+			//exit(1);
+		}*/
+		int ret = av_frame_make_writable(frame);
+		if (ret < 0)
+		{
+			PVR_DB("PVRffmpeg::ProcessSharedHandle() Could not make AV_FRame Writable");
+			//exit(1);
+		}
+
+		//ID3D11Texture2D* hwTexture = (ID3D11Texture2D *)(frame->data[0]);
+		//DXGI_FORMAT_NV12
+		//**** Loop This for fps Times
+		
+		ID3D11Texture2D *inpTex;
+		HRESULT hr = avHWDevice->OpenSharedResource((HANDLE)gfxSharedHandle, __uuidof(ID3D11Texture2D), (void **)&inpTex);
+		if (FAILED(hr))
+		{
+			PVR_DB("PVRffmpeg::ProcessSharedHandle() Failed to OpenSharedResource, D3DHWDevFeatureLevel: " + to_string(avHWDevice->GetFeatureLevel()) );
+			debugHr(hr);
+			//return;
+		}
+
+		IDXGIKeyedMutex *dxMtx;
+		hr = inpTex->QueryInterface(__uuidof(dxMtx), reinterpret_cast<void**>(&dxMtx));
+		if (FAILED(hr))
+		{
+			PVR_DB("PVRffmpeg::ProcessSharedHandle() Failed to QueryInterface");
+			debugHr(hr);
+			//return;
+		}
+
+		if (SUCCEEDED(dxMtx->AcquireSync(0, 500))) {
+			avHWDevice_context->CopyResource(stagingTex, inpTex); //texAmp is automatically updated
+			dxMtx->ReleaseSync(0);
+		}
+
+		//ID3D11Texture2D* hwTexture = (ID3D11Texture2D *)(frame->data[0]);
+		frame->data[0] = (uint8_t *)stagingTex;
+		frame->data[1] = 0;
+
+		RELEASE(dxMtx);
+		RELEASE(inpTex);
+
+		//****
+
+		//(*hwTexture).GetDevice(&hwDevice);
+
+		/*ID3D11DeviceContext* hwDeviceCtx;
+		hwDevice->GetImmediateContext(&hwDeviceCtx);
+
+		ID3D11Texture2D* sharedTexture;
+
+		HRESULT hr = hwDevice->OpenSharedResource((HANDLE) gfxSharedHandle, __uuidof(ID3D11Texture2D), (void**)&inpTex);
+		if (FAILED(hr))
+		{
+			PVR_DB("PVRffmpeg::Stream() Failed to obtaion open shared resource.");
+			return;
+		}
+
+		int index = *frame->data[1];
+		hwDeviceCtx->CopySubresourceRegion(sharedTexture, 0, 0, 0, 0, hwTexture, index, NULL);*/
+
+		/* flush the encoder */
+		encode(OutputEncoderContext, frame, pkt, OutputContext);
+
+		/* add sequence end code to have a real MPEG file */
+		//fwrite(endcode, 1, sizeof(endcode), f);
+		//fclose(f);
+
+		//avcodec_free_context(&OutputEncoderContext);
+
+	fail:
+		av_frame_unref(frame);
+		{
+			PVR_DB("failed : " + to_string(ret));
+		}
+		av_frame_free(&frame);
+		av_packet_free(&pkt);
+	}
+
+	mgfxSharedHandle.unlock();
+}
+
+void  PVRffmpeg::debugHr(HRESULT hr) 
+{
+	LPWSTR output;
+	FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_ALLOCATE_BUFFER,
+		NULL, hr, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&output, 0, NULL);
+	PVR_DB_I(wstring(output));
+}
+
+void PVRffmpeg::Stream()
+{
+	//	av_dict_set(&sws_dict, "flags", "bicubic", 0);
+	int result = avformat_alloc_output_context2(&OutputContext, NULL, "rtp", "rtp://127.0.0.1");
+
+	// Using SW libx264 Codec
+	//vVideoCodech264 = avcodec_find_encoder(AV_CODEC_ID_H264);
+	vVideoCodecNVENC = avcodec_find_encoder_by_name("h264_nvenc"); // Type 2 Encoder	
+	OutputVideoStream = avformat_new_stream(OutputContext, vVideoCodecNVENC);
+
+	OutputEncoderContext = avcodec_alloc_context3(vVideoCodecNVENC);
+
+	result = av_hwdevice_ctx_create(&nvencD3D11DeviceContext, AV_HWDEVICE_TYPE_D3D11VA, "d3d11va", NULL, 0);
+	nvencD3D11DeviceCtx = (AVHWDeviceContext*)nvencD3D11DeviceContext->data;
+
+	nvencHWFramesContext = av_hwframe_ctx_alloc(nvencD3D11DeviceContext);
+	
+	AVHWFramesContext* AVHWFramesCTx = (AVHWFramesContext *)nvencHWFramesContext->data;
+	AVHWFramesCTx->format = AV_PIX_FMT_D3D11;
+
+	OutputEncoderContext->hw_frames_ctx = nvencHWFramesContext;
+
+	if (!OutputEncoderContext) 
+	{
+		PVR_DB("PVRffmpeg::Stream() Could not allocate video codec context");
+		exit(1);
+	}
+	
+	OutputEncoderContext->bit_rate = 400000;
+	OutputEncoderContext->width = width;
+	OutputEncoderContext->height = height;
+
+	OutputEncoderContext->time_base = AVRational { 1, 60 };
+	OutputEncoderContext->framerate = AVRational { 60, 1 };
+
+	OutputEncoderContext->gop_size = 10;
+	OutputEncoderContext->max_b_frames = 1;
+	OutputEncoderContext->pix_fmt = AV_PIX_FMT_D3D11;
+
+	PVR_DB("PVRffmpeg::Stream(): AVHWFramesPixFormate : " + to_string(AVHWFramesCTx->format) + " & OutputEncoderContext PixFmt: " + to_string(AV_PIX_FMT_D3D11));
+
+	if (vVideoCodecNVENC->id == AV_CODEC_ID_H264)
+		av_opt_set(OutputEncoderContext->priv_data, "preset", "slow", 0);
+
+	/* open it */
+
+	int ret = avcodec_open2(OutputEncoderContext, vVideoCodecNVENC, NULL);
+	if (ret < 0) {
+		PVR_DB("PVRffmpeg::Stream() Could not open codec: %s"+ to_string(ret));
+		//exit(1);
+	}
+	
+	AVD3DhwDevice = (AVD3D11VADeviceContext *)nvencD3D11DeviceCtx->hwctx;
+
+	avHWDevice = AVD3DhwDevice->device;
+	avHWDevice_context = AVD3DhwDevice->device_context;
+
+	D3D11_TEXTURE2D_DESC texDesc = {};
+	texDesc.Width = width;
+	texDesc.Height = height;
+	texDesc.MipLevels = 1;
+	texDesc.ArraySize = 1;
+	texDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	texDesc.SampleDesc.Count = 1;
+	texDesc.Usage = D3D11_USAGE_DEFAULT;
+	texDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS;
+	texDesc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+
+	HRESULT hr = avHWDevice->CreateTexture2D(&texDesc, nullptr, &stagingTex);
+	if (FAILED(hr))
+	{
+		PVR_DB_I("######### DirectX Error: #########");
+		debugHr(hr);
+	}
+}
+
+void PVRffmpeg::encode(AVCodecContext *enc_ctx, AVFrame *frame, AVPacket *pkt, AVFormatContext *outputContext)
+{
+	int ret;
+	/* send the frame to the encoder */
+	if (frame)
+	{
+		PVR_DB("PVRffmpeg::encode() Send frame %d" + to_string(frame->pts));
+	}
+
+	ret = avcodec_send_frame(enc_ctx, frame);
+	if (ret < 0) {
+		PVR_DB("PVRffmpeg::encode() Error sending a frame for encoding");
+		//exit(1);
+	}
+	while (ret >= 0) {
+		ret = avcodec_receive_packet(enc_ctx, pkt);
+		if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+			return;
+		else if (ret < 0) {
+			PVR_DB("PVRffmpeg::encode() Error during encoding");
+			//exit(1);
+		}
+		PVR_DB("PVRffmpeg::encode() Write packet "+to_string(pkt->pts)+" (size=" + to_string(pkt->size)+ ")\n" );
+
+		av_write_frame(outputContext, pkt);
+
+		//fwrite(pkt->data, 1, pkt->size, outfile);
+		av_packet_unref(pkt);
+	}
+}
+
+void PVRffmpeg::StopStreaming()
+{
+
+}

--- a/code/windows/PhoneVR/PhoneVR/PVRffmpeg.h
+++ b/code/windows/PhoneVR/PhoneVR/PVRffmpeg.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <iostream>
+#include <d3d11.h>
+
+extern "C"
+{
+#include "libavutil/avutil.h"
+#include "libavformat/avformat.h"
+#include "libavdevice/avdevice.h"
+#include "libavutil/hwcontext_d3d11va.h"
+}
+
+#pragma comment(lib, "avcodec.lib")
+#pragma comment(lib, "avutil.lib")
+#pragma comment(lib, "avformat.lib")
+#pragma comment(lib, "avdevice.lib")
+
+#include "PVRMath.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "openvr_driver.h"
+
+#define RELEASE(obj) if(obj) { obj->Release(); obj = nullptr; }
+#define OK_OR_EXEC(call, func) if(FAILED(call)) func()
+
+using namespace std;
+using namespace Eigen;
+using namespace vr;
+
+class PVRffmpeg
+{
+	int width, height, remotePort;
+	string remoteIP;
+
+	mutex mgfxSharedHandle;
+	SharedTextureHandle_t gfxSharedHandle = INVALID_SHARED_TEXTURE_HANDLE;
+	Quaternionf quat;
+
+	AVFormatContext *OutputContext;
+	AVCodec *vVideoCodech264;
+	AVCodec *vVideoCodecNVENC; // This is Encoder
+	AVStream *OutputVideoStream;
+	AVCodecContext *OutputEncoderContext;
+
+	AVBufferRef *nvencD3D11DeviceContext = NULL;
+	AVBufferRef *nvencHWFramesContext = NULL;
+
+	AVHWDeviceContext *nvencD3D11DeviceCtx = NULL;
+	AVD3D11VADeviceContext* AVD3DhwDevice = NULL;
+
+	ID3D11Device        *avHWDevice = NULL;
+	ID3D11DeviceContext *avHWDevice_context = NULL;
+
+	ID3D11Texture2D* stagingTex = NULL;
+
+	void encode(AVCodecContext * enc_ctx, AVFrame * frame, AVPacket * pkt, AVFormatContext * outputContext);
+
+public:
+	PVRffmpeg();
+	~PVRffmpeg();
+
+	void setSettings(int width, int height, string remoteIP, int port);
+	void Stream();
+	void StopStreaming();
+	void ProcessSharedHandle(SharedTextureHandle_t gfxSharedHandle, Quaternionf quat);
+	void debugHr(HRESULT hr);
+};

--- a/code/windows/PhoneVR/PhoneVR/PVRffmpegBackgroundProcess.cpp
+++ b/code/windows/PhoneVR/PhoneVR/PVRffmpegBackgroundProcess.cpp
@@ -1,0 +1,331 @@
+#include "PVRffmpegBackgroundProcess.h"
+/*
+int PVRffmpegBackgroundProcess::initffmpeg()
+{
+	return 0;
+}
+
+int PVRffmpegBackgroundProcess::Resample()
+{
+	// Source and Target WxH will be same in PVR
+	struct SwsContext* scaler = sws_getContext(
+		width, height, AV_PIX_FMT_YUYV422,
+		width, height, AV_PIX_FMT_YUV422P,
+		SWS_BICUBIC, NULL, NULL, NULL
+	);
+
+	AVFrame* scaled_frame = av_frame_alloc();
+
+	scaled_frame->format = AV_PIX_FMT_YUV422P;
+	scaled_frame->width = width;
+	scaled_frame->height = height;
+
+	av_image_alloc(	scaled_frame->data, scaled_frame->linesize,	scaled_frame->width, scaled_frame->height,
+		(AVPixelFormat) scaled_frame->format, 16);
+
+	/*sws_scale(scaler,
+		(const uint8_t * const*)source_data, source_linesize,
+		0, source_height,
+		scaled_frame->data, scaled_frame->linesize);
+
+	av_frame_free(&scaled_frame);
+	return 0;
+}
+
+int PVRffmpegBackgroundProcess::Encode(AVFrame* scaled_frame)
+{
+	avformat_network_init();
+	avcodec_register_all();
+
+	AVCodec* codec = avcodec_find_encoder(AV_CODEC_ID_H264);
+
+	AVCodecContext* encoder = avcodec_alloc_context3(codec);
+
+	encoder->bit_rate = 10 * 1000 * 10000;
+	encoder->width = 1920;
+	encoder->height = 1080;
+	encoder->time_base = AVRational { 1, 60 };
+	encoder->gop_size = 30;
+	encoder->max_b_frames = 1;
+	encoder->pix_fmt = AV_PIX_FMT_YUV422P;
+
+//	av_opt_set(encoder->av_codec_context->priv_data, "preset", "ultrafast", 0);
+
+	avcodec_open2(encoder, codec, NULL);
+
+	AVFrame* raw_frame = scaled_frame;
+
+	raw_frame->pts = pts++;
+	avcodec_send_frame(encoder, raw_frame);
+
+	av_freep(&raw_frame->data[0]);
+	av_frame_free(&raw_frame);
+
+	return 0;
+}
+
+int PVRffmpegBackgroundProcess::MuxAV(AVCodecContext* encoder)
+{
+	AVFormatContext* muxer = avformat_alloc_context();
+
+	muxer->oformat = av_guess_format("matroska", "rtp://127.0.0.1:40000", NULL);
+
+	AVStream* video_track = avformat_new_stream(muxer, NULL);
+	AVStream* audio_track = avformat_new_stream(muxer, NULL);
+	muxer->oformat->video_codec = AV_CODEC_ID_H264;
+	muxer->oformat->audio_codec = AV_CODEC_ID_OPUS;
+
+	avcodec_parameters_from_context(video_track->codecpar, encoder);
+	video_track->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
+
+	video_track->time_base = AVRational { 1, 60 };
+	video_track->avg_frame_rate = AVRational { 60, 1 };
+
+	AVDictionary *options = NULL;
+	av_dict_set(&options, "live", "1", 0);
+	avformat_write_header(muxer, &options);
+	return 0;
+}
+
+int PVRffmpegBackgroundProcess::startStream()
+{
+	return 0;
+}
+*/
+
+int PVRffmpegBackgroundProcess::initFFMPEGChildProcess()
+{
+	//int main(int argc, char *argv[]) {
+	SECURITY_ATTRIBUTES sa;
+	printf("\n->Start of parent execution.\n");
+	// Set the bInheritHandle flag so pipe handles are inherited. 
+	sa.nLength = sizeof(SECURITY_ATTRIBUTES);
+	sa.bInheritHandle = TRUE;
+	sa.lpSecurityDescriptor = NULL;
+
+	// Create a pipe for the child process's STDERR. 
+	if (!CreatePipe(&g_hChildStd_ERR_Rd, &g_hChildStd_ERR_Wr, &sa, 0)) {
+		exit(1);
+	}
+	// Ensure the read handle to the pipe for STDERR is not inherited.
+	if (!SetHandleInformation(g_hChildStd_ERR_Rd, HANDLE_FLAG_INHERIT, 0)) {
+		exit(1);
+	}
+
+	// Create a pipe for the child process's STDOUT. 
+	if (!CreatePipe(&g_hChildStd_OUT_Rd, &g_hChildStd_OUT_Wr, &sa, 0)) {
+		exit(1);
+	}
+	// Ensure the read handle to the pipe for STDOUT is not inherited
+	if (!SetHandleInformation(g_hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT, 0)) {
+		exit(1);
+	}
+
+	if (!CreatePipe(&g_hChildStd_IN_Rd, &g_hChildStd_IN_Wr, &sa, 16358400)) {
+		exit(1);
+	}
+	if (!SetHandleInformation(g_hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0)) {
+		exit(1);
+	}
+	return 0;
+}
+
+void PVRffmpegBackgroundProcess::startSTDOutPipeReader()
+{
+	PVR_DB("PVRffmpegBackgroundProcess::startSTDOutPipeReader() Starting ...");
+	std::thread* iCProcessReader = new std::thread([=] {
+		ReadFromSTDOutPipe(piProcInfo);
+	});
+}
+
+void PVRffmpegBackgroundProcess::startSTDErrPipeReader()
+{
+	PVR_DB("PVRffmpegBackgroundProcess::startSTDErrPipeReader() Starting ...");
+	std::thread* iCProcessReader = new std::thread([=] {
+		ReadFromSTDErrPipe(piProcInfo);
+	});
+}
+
+int PVRffmpegBackgroundProcess::CreateFFMPEGChildProcess()
+{
+	if (bProcessStarted) 
+		return 1;
+	// Create the child process. 
+	piProcInfo = CreateChildProcess();
+	bProcessStarted = true;
+
+	// Read from pipe that is the standard output for child process. 
+	//printf("\n->Contents of child process STDOUT:\n\n", argv[1]);
+
+	PVR_DB("PVRffmpegBackgroundProcess::CreateFFMPEGChildProcess() Created child Process");
+
+	// The remaining open handles are cleaned up when this process terminates. 
+	// To avoid resource leaks in a larger application, 
+	//   close handles explicitly.
+	return 0;
+	//}
+}
+
+bool PVRffmpegBackgroundProcess::isChildProcessRunning()
+{
+	return bProcessStarted;
+}
+
+
+// Create a child process that uses the previously created pipes
+//  for STDERR and STDOUT.
+PROCESS_INFORMATION PVRffmpegBackgroundProcess::CreateChildProcess() 
+{
+	std::wstring szPath = L"C:\\Program Files\\ffmpeg\\bin\\ffmpeg.exe";
+	std::wstring szCmdline = L"ffmpeg -re -f rawvideo -i pipe: -vcodec H264 -an -f rtp rtp://127.0.0.1:40000";
+
+	PROCESS_INFORMATION piProcInfo;
+	STARTUPINFO siStartInfo;
+	bool bSuccess = FALSE;
+
+	// Set up members of the PROCESS_INFORMATION structure. 
+	ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
+
+	// Set up members of the STARTUPINFO structure. 
+	// This structure specifies the STDERR and STDOUT handles for redirection.
+	ZeroMemory(&siStartInfo, sizeof(STARTUPINFO));
+	siStartInfo.cb = sizeof(STARTUPINFO);
+	siStartInfo.hStdError = g_hChildStd_ERR_Wr;
+	siStartInfo.hStdOutput = g_hChildStd_OUT_Wr;
+	siStartInfo.hStdInput = g_hChildStd_IN_Rd;
+	siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
+
+	// Create the child process. 
+	bSuccess = CreateProcess(szPath.c_str(),
+		L"ffmpeg -re -f rawvideo -video_size 1704x960 -r 60 -i pipe:0 -vcodec h264 -an -f rtp rtp://127.0.0.1:40000",     // command line 
+		NULL,          // process security attributes 
+		NULL,          // primary thread security attributes 
+		TRUE,          // handles are inherited 
+		0,             // creation flags 
+		NULL,          // use parent's environment 
+		NULL,          // use parent's current directory 
+		&siStartInfo,  // STARTUPINFO pointer 
+		&piProcInfo);  // receives PROCESS_INFORMATION
+	CloseHandle(g_hChildStd_ERR_Wr);
+	CloseHandle(g_hChildStd_OUT_Wr);
+	CloseHandle(g_hChildStd_IN_Rd);
+	// If an error occurs, exit the application. 
+	if (!bSuccess) {
+		PVR_DB("PVRffmpegBackgroundProcess::CreateChildProcess(): Could not create PVRffmpeg Child Process... Exiting... Error: " + GetLastErrorAsString());
+		exit(1);
+	}
+	return piProcInfo;
+}
+
+//Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+std::string PVRffmpegBackgroundProcess::GetLastErrorAsString()
+{
+	//Get the error message, if any.
+	DWORD errorMessageID = ::GetLastError();
+	if (errorMessageID == 0)
+		return std::string(); //No error message has been recorded
+
+	LPSTR messageBuffer = nullptr;
+	size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+	std::string message(messageBuffer, size);
+
+	//Free the buffer.
+	LocalFree(messageBuffer);
+
+	return (std::to_string(errorMessageID) + ": " + message);
+}
+
+// Read output from the child process's pipe for STDOUT
+// and write to the parent process's pipe for STDOUT. 
+// Stop when there is no more data. 
+void PVRffmpegBackgroundProcess::ReadFromSTDOutPipe(PROCESS_INFORMATION piProcInfo)
+{
+	DWORD dwRead;
+	CHAR chBuf[BUFSIZE];
+	bool bSuccess = FALSE;
+	std::string out = "", err = "";
+	while (1)
+	{
+		for (;;) 
+		{
+			bSuccess = ReadFile(g_hChildStd_OUT_Rd, chBuf, BUFSIZE, &dwRead, NULL);
+			if (!bSuccess || dwRead == 0) break;
+
+			std::string s(chBuf, dwRead);
+
+			PVR_DB("stdout: " + s);
+			out += s;
+		}
+		//std::cout << "stdout:" << out << std::endl;
+		//std::cout << "stderr:" << err << std::endl;
+		//PVR_DB("stdout: " + out);
+		//PVR_DB("stderr: " + err);
+	}
+}
+
+void PVRffmpegBackgroundProcess::ReadFromSTDErrPipe(PROCESS_INFORMATION piProcInfo)
+{
+	DWORD dwRead;
+	CHAR chBuf[64];
+	bool bSuccess = FALSE;
+	std::string out = "";//, err = "";
+	while (1)
+	{
+		for (;;)
+		{
+			bSuccess = ReadFile(g_hChildStd_ERR_Rd, chBuf, 64, &dwRead, NULL);
+			if (!bSuccess || dwRead == 0) break;
+
+			std::string s(chBuf, dwRead);
+
+			PVR_DB(s + " -- Child:stderr" );
+			//err += s;
+
+		}
+		//std::cout << "stdout:" << out << std::endl;
+		//std::cout << "stderr:" << err << std::endl;
+		//PVR_DB("stdout: " + out);
+		//PVR_DB("stderr: " + err);
+	}
+}
+
+int PVRffmpegBackgroundProcess::WriteToPipe(void* data, int datalen)
+{
+	DWORD dwWritten;
+	bool bSuccess = FALSE;
+	bSuccess = WriteFile(g_hChildStd_IN_Wr, data, datalen, &dwWritten, NULL);
+
+	return bSuccess ? dwWritten : -1;
+}
+
+float PVRffmpegBackgroundProcess::WriteToPipe(x264_picture_t* pic, int dataPerStride /*height, should be <= 65,535 bytes */)
+{
+	DWORD dwWritten;
+	bool bSuccess = FALSE;
+
+	int totalData = dataPerStride * (pic->img.i_stride[0] + pic->img.i_stride[1] + pic->img.i_stride[2]);
+	int dataWritten = 0;
+	for (int i = 0; i < pic->img.i_plane; i++)
+	{		
+		for (int j = 0; j < pic->img.i_stride[i]; j++)
+		{
+			bSuccess = WriteFile(g_hChildStd_IN_Wr, pic->img.plane[i] + (j*dataPerStride), dataPerStride, &dwWritten, NULL);
+			if (bSuccess)
+			{
+				dataWritten += (int)dwWritten;
+			}
+			else
+			{
+				PVR_DB("PVRffmpegBackgroundProcess::WriteToPipe() Writing .. Plane : " + std::to_string(i)  + 
+					", Stride: " + std::to_string(j) + ", DataperString: " +
+					std::to_string(dataPerStride) + ", Retrun: " +
+					std::to_string(bSuccess) + ", Written: " +
+					std::to_string(dwWritten) + ", Last Error: " + GetLastErrorAsString());
+			}
+		}
+	}
+
+	return ((float)dataWritten/totalData);
+}

--- a/code/windows/PhoneVR/PhoneVR/PVRffmpegBackgroundProcess.h
+++ b/code/windows/PhoneVR/PhoneVR/PVRffmpegBackgroundProcess.h
@@ -1,0 +1,63 @@
+
+/*#include "libswscale/swscale.h"
+#include "libavcodec/avcodec.h"
+#include "libavformat/avformat.h"
+
+#include "libavutil/imgutils.h"
+#include "libavutil/opt.h"
+*/
+#include <string>
+#include <iostream>
+#include <windows.h> 
+#include <stdio.h>
+#include <string>
+
+extern "C"
+{
+#include "x264.h"
+}
+
+#include <PVRGlobals.h>
+#pragma warning( disable : 4800 ) // stupid warning about bool
+#define BUFSIZE 256
+
+class PVRffmpegBackgroundProcess
+{
+	int width = 1920, height = 1080;
+	int64_t pts = 0;
+	PROCESS_INFORMATION piProcInfo;
+
+	HANDLE g_hChildStd_OUT_Rd = NULL;
+	HANDLE g_hChildStd_OUT_Wr = NULL;
+	HANDLE g_hChildStd_ERR_Rd = NULL;
+	HANDLE g_hChildStd_ERR_Wr = NULL;
+	HANDLE g_hChildStd_IN_Rd = NULL;
+	HANDLE g_hChildStd_IN_Wr = NULL;
+
+	bool bProcessStarted = false;
+
+	PROCESS_INFORMATION CreateChildProcess(void);
+public:
+	PVRffmpegBackgroundProcess() {}
+	~PVRffmpegBackgroundProcess() {}
+	/*int initffmpeg();
+	int Resample();
+	int Encode(AVFrame* scaled_frame);
+	int MuxAV(AVCodecContext* encoder);
+	int Encode();
+	int MuxAV();
+	int startStream();*/
+	
+	int initFFMPEGChildProcess();
+	void startSTDOutPipeReader();
+	void startSTDErrPipeReader();
+	int CreateFFMPEGChildProcess();
+
+	bool isChildProcessRunning();
+	std::string GetLastErrorAsString();
+	
+	void ReadFromSTDOutPipe(PROCESS_INFORMATION piProcInfo);
+	void ReadFromSTDErrPipe(PROCESS_INFORMATION piProcInfo);
+	int WriteToPipe(void * data, int datalen);
+	float WriteToPipe(x264_picture_t * pic, int dataPerPlane);
+};

--- a/code/windows/PhoneVR/PhoneVR/PhoneVR.vcxproj
+++ b/code/windows/PhoneVR/PhoneVR/PhoneVR.vcxproj
@@ -50,7 +50,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -78,6 +78,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)$(Configuration)\$(Platform)\</OutDir>
+    <IncludePath>$(FFMPEG_MASTER)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(FFMPEG_MASTER)\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -108,16 +110,20 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_WIN32_WINNT=0x0601;_DEBUG;_WINDOWS;_USRDLL;PHONEVR_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0601;NDEBUG;PVR_DEBUG;_WINDOWS;_USRDLL;PHONEVR_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)\$(ProjectName);$(SolutionDir)\..\..\common\src;$(SolutionDir)\..\libs\json;$(SolutionDir)\..\libs\x264\include;$(SolutionDir)\..\..\common\libs\asio;$(SolutionDir)\..\..\common\libs\eigen;$(SolutionDir)\..\..\common\src\Utils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\libs\x264\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AssemblyDebug>
+      </AssemblyDebug>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)$(Configuration)\$(Platform)" "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\drivers\PVRServer\bin\win64" /h /i /c /k /e /r /y</Command>
+      <Command>$(SolutionDir)post_build_debug.cmd</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -144,12 +150,16 @@
       <WarningLevel>Level1</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
       <PreprocessorDefinitions>_WIN32_WINNT=0x0601;NDEBUG;_WINDOWS;_USRDLL;PHONEVR_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)\$(ProjectName);$(SolutionDir)\..\..\common\src;$(SolutionDir)\..\libs\json;$(SolutionDir)\..\libs\x264\include;$(SolutionDir)\..\..\common\libs\asio;$(SolutionDir)\..\..\common\libs\eigen;$(SolutionDir)\..\..\common\src\Utils;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <SupportJustMyCode>true</SupportJustMyCode>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -158,13 +168,17 @@
       <AdditionalLibraryDirectories>$(SolutionDir)\..\libs\x264\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(SolutionDir)$(Configuration)\$(Platform)" "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\drivers\PVRServer\bin\win64" /h /i /c /k /e /r /y</Command>
+      <Command>$(SolutionDir)post_build_release.cmd</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\common\src\PVRGlobals.cpp" />
     <ClCompile Include="..\..\..\common\src\PVRSocketUtils.cpp" />
     <ClCompile Include="driver.cpp" />
+    <ClCompile Include="PVRffmpeg.cpp">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="PVRffmpegBackgroundProcess.cpp" />
     <ClCompile Include="PVRGraphics.cpp" />
     <ClCompile Include="PVRMath.cpp" />
     <ClCompile Include="PVRSockets.cpp" />
@@ -175,6 +189,8 @@
     <ClInclude Include="..\..\..\common\src\Utils\StrUtils.h" />
     <ClInclude Include="..\..\..\common\src\Utils\ThreadUtils.h" />
     <ClInclude Include="openvr_driver.h" />
+    <ClInclude Include="PVRffmpeg.h" />
+    <ClInclude Include="PVRffmpegBackgroundProcess.h" />
     <ClInclude Include="PVRGraphics.h" />
     <ClInclude Include="PVRFileManager.h" />
     <ClInclude Include="PVRMath.h" />

--- a/code/windows/PhoneVR/PhoneVR/PhoneVR.vcxproj.filters
+++ b/code/windows/PhoneVR/PhoneVR/PhoneVR.vcxproj.filters
@@ -33,6 +33,12 @@
     <ClCompile Include="PVRGraphics.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="PVRffmpegBackgroundProcess.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PVRffmpeg.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="openvr_driver.h">
@@ -60,6 +66,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\common\src\Utils\ThreadUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PVRffmpegBackgroundProcess.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PVRffmpeg.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/code/windows/PhoneVR/PhoneVR/post_build.cmd
+++ b/code/windows/PhoneVR/PhoneVR/post_build.cmd
@@ -1,0 +1,3 @@
+xcopy "C:\Users\narni\Documents\GitHub\PhoneVR\code\windows\PhoneVR\Debug\x64" "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\drivers\PVRServer\bin\win64" /h /i /c /k /e /r /y
+
+explorer "steam://rungameid/250820"

--- a/code/windows/PhoneVR/post_build_debug.cmd
+++ b/code/windows/PhoneVR/post_build_debug.cmd
@@ -1,0 +1,19 @@
+@ECHO OFF
+
+xcopy "C:\Users\narni\Documents\GitHub\PhoneVR\code\windows\PhoneVR\Debug\x64" "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\drivers\PVRServer\bin\win64" /h /i /c /k /e /r /y
+
+::CALL explorer "steam://rungameid/250820"
+
+:::LOOP
+::tasklist | find /i "vrserver" >nul 2>&1
+::IF ERRORLEVEL 1 (
+::  ECHO vrserver is still starting
+::  GOTO LOOP
+::) ELSE (
+::  ECHO vrserver started
+::  GOTO CONTINUE
+::)
+
+:CONTINUE
+
+exit 0

--- a/code/windows/PhoneVR/post_build_release.cmd
+++ b/code/windows/PhoneVR/post_build_release.cmd
@@ -1,0 +1,19 @@
+@ECHO OFF
+
+xcopy "C:\Users\narni\Documents\GitHub\PhoneVR\code\windows\PhoneVR\Release\x64" "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\drivers\PVRServer\bin\win64" /h /i /c /k /e /r /y
+
+CALL explorer "steam://rungameid/250820"
+
+:LOOP
+tasklist | find /i "vrserver" >nul 2>&1
+IF ERRORLEVEL 1 (
+  ECHO vrserver is still starting
+  GOTO LOOP
+) ELSE (
+  ECHO vrserver started
+  GOTO CONTINUE
+)
+
+:CONTINUE
+
+exit 0


### PR DESCRIPTION
Hardware Encoding Support and Network hand-wave latency reduction
```
Old/deprecated
- [x] Research low-latency Protocols: Done: RTP best for this application.
- [x] Research Available libraries
    - [x] PJ-SIP, FFMPEG
    - [x] PJ-SIP - Tests: Status: [Failed no pj-media Support](https://github.com/pjsip/pjproject/issues/2601).
    - [ ] Implement FFMPEG
        - [ ] Implement FFMPEG on Desktop
            - [x] Protocols Selection: RTP (ultra-low latency) + NVENC/NVDEC Encoder (h.264 Container format)
            - [ ] Code Implementation:
                - [x] Implement ffmpeg as ffmpeg-cli commandLineInterface integration
                    - [x] Stage0 - Research D3DSharedResourceHandle Streaming
                        - [x] Test1: using Inprocess pipes to get pipe render to ffmpeg for encoding. Status: Failed - WritePipe() Speed too low (~15 fps)
                        - [x] Test2: Piping D3DSharedResourceHandle to ffmpeg.exe process in background. Status Failed - Hard to maintain with FFMPEG-master updates, better to implement libav*
                            - [x] ~Bypass Mobile negotiation, for Development~
                            - [x] ~Modify FFMPEG fopen_inputs() to get D3DSharedResourceHandle~
                - [ ] Implement ffmpeg as libav* libraries, if Test1 & 2 Both fail.
                    - [ ] Stage1 - Static Content Streaming
                        - [ ] Stream Static testfile.mp4, with RTP to localhost, for Dev
                            - [x] Bypass Mobile negotiation, for Development
                            - [x] Code FFMPEG Init()
                            - [x] Code FFMPEG fopen_inputs()
                            - [x] Code FFMPEG fopen_outputs()
                            - [x] Code FFMPEG transcode()
                                - [x] Code FFMPEG transcode_init()
                                - [x] Code FFMPEG transcode_step() <--- Main Loop
                            - [ ] Code FFMPEG stop_stream(), Outputs and Inputs
                            - [x] Code FFMPEG deInit() <--- safe exit + Memory Release
                    - [ ] Stage2 - Dynamic Content Streaming
                        - [ ] Modify FFMPEG fopen_inputs() to get D3DSharedResourceHandle
                            - [x] Research methodology
                            - [x] Modify FFMPEG fopen_inputs() to take D3DSharedResourceHandle as Input instead of Static file
        - [ ] Implement FFMPEG on Mobile End
            - [ ] Add shared libraries (.so) to Android project.
            - [ ] Research into available FFMPEGAndroid ports/wrappers
                - [ ] Test3: Port Wrapper Implementation test on Android
            - [ ] If Test3 not successful, implement FFMPEG libav* code.
            
```
Fixes #44 and #52