### PR TITLE
feat: camera pass-through mode

### DIFF
--- a/code/mobile/android/PhoneVR/app/CMakeLists.txt
+++ b/code/mobile/android/PhoneVR/app/CMakeLists.txt
@@ -21,6 +21,7 @@ file(GLOB_RECURSE GVR_SRC
 
 add_library(native-lib-alvr SHARED
     src/main/cpp/alvr_main.cpp
+    src/main/cpp/passthrough.cpp
     ${LIB_SRC}
 )
 

--- a/code/mobile/android/PhoneVR/app/build.gradle
+++ b/code/mobile/android/PhoneVR/app/build.gradle
@@ -132,9 +132,12 @@ android {
     }
 }
 
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation fileTree(dir: "libraries", include: ['hellocharts-2.6.5.aar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
@@ -161,6 +164,7 @@ dependencies {
 
     implementation platform('com.google.firebase:firebase-bom:26.0.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
 }
 
 // The dependencies for NDK builds live inside the .aar files so they need to

--- a/code/mobile/android/PhoneVR/app/build.gradle
+++ b/code/mobile/android/PhoneVR/app/build.gradle
@@ -134,6 +134,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: "libraries", include: ['hellocharts-2.6.5.aar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/code/mobile/android/PhoneVR/app/build.gradle
+++ b/code/mobile/android/PhoneVR/app/build.gradle
@@ -95,7 +95,7 @@ android {
     }
     project.gradle.taskGraph.whenReady {
         android.productFlavors.all { flavor ->
-            // Capitalize (as Gralde is case-sensitive).
+            // Capitalize (as Gradle is case-sensitive).
             def flavorName = flavor.name.substring(0, 1).toUpperCase() + flavor.name.substring(1)
 
             // At last, configure.
@@ -140,6 +140,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
 
     implementation "androidx.tracing:tracing:1.1.0"
+    implementation 'androidx.preference:preference:1.2.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation "androidx.test.ext:junit-ktx:$extJUnitVersion"

--- a/code/mobile/android/PhoneVR/app/src/main/AndroidManifest.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/AndroidManifest.xml
@@ -47,6 +47,10 @@
         tools:replace="android:extractNativeLibs"
         android:extractNativeLibs="true">
         <activity
+            android:name=".PassthroughSettingsActivity"
+            android:exported="false"
+            android:label="@string/title_activity_passthrough_settings" />
+        <activity
             android:name=".InitActivity"
             android:label="@string/app_name"
             android:exported="true">

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
@@ -12,6 +12,7 @@
 
 #include "nlohmann/json.hpp"
 #include "utils.h"
+#include "passthrough.h"
 
 using namespace nlohmann;
 
@@ -38,6 +39,7 @@ struct NativeContext {
 
     bool running = false;
     bool streaming = false;
+    PassthroughInfo passthroughInfo = {};
     std::thread inputThread;
 
     // Une one texture per eye, no need for swapchains.
@@ -188,6 +190,10 @@ extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_initia
 
     Cardboard_initializeAndroid(CTX.javaVm, CTX.javaContext);
     CTX.headTracker = CardboardHeadTracker_create();
+
+    CTX.passthroughInfo.screenWidth = &(CTX.screenWidth);
+    CTX.passthroughInfo.screenHeight = &(CTX.screenHeight);
+    passthrough_createPlane(&(CTX.passthroughInfo));
 }
 
 extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_destroyNative(JNIEnv *,
@@ -233,11 +239,24 @@ extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_pauseN
     CardboardHeadTracker_pause(CTX.headTracker);
 }
 
+extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_Passthrough_setPassthroughActiveNative(
+    JNIEnv *, jobject, jboolean activate) {
+    CTX.passthroughInfo.enabled = activate;
+    CTX.renderingParamsChanged = true;
+}
+
 extern "C" JNIEXPORT void JNICALL
+Java_viritualisres_phonevr_Passthrough_setPassthroughSizeNative(JNIEnv *, jobject, jfloat size) {
+    CTX.passthroughInfo.passthroughSize = size;
+    passthrough_createPlane(&(CTX.passthroughInfo));
+}
+
+extern "C" JNIEXPORT jint JNICALL
 Java_viritualisres_phonevr_ALVRActivity_surfaceCreatedNative(JNIEnv *, jobject) {
     alvr_initialize_opengl();
-
+    GLuint camTex = passthrough_init(&(CTX.passthroughInfo));
     CTX.glContextRecreated = true;
+    return camTex;
 }
 
 extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_setScreenResolutionNative(
@@ -308,38 +327,41 @@ extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_render
         if (CTX.renderingParamsChanged && !CTX.glContextRecreated) {
             info("Pausing ALVR since glContext is not recreated, deleting textures");
             alvr_pause_opengl();
-
+            passthrough_cleanup(&(CTX.passthroughInfo));
             GL(glDeleteTextures(2, CTX.lobbyTextures));
         }
 
         if (CTX.renderingParamsChanged || CTX.glContextRecreated) {
-            info("Rebuilding, binding textures, Resuming ALVR since glContextRecreated %b, "
-                 "renderingParamsChanged %b",
-                 CTX.renderingParamsChanged,
-                 CTX.glContextRecreated);
-            GL(glGenTextures(2, CTX.lobbyTextures));
+            if (CTX.passthroughInfo.enabled) {
+                passthrough_setup(&(CTX.passthroughInfo));
+            } else {
+                info("Rebuilding, binding textures, Resuming ALVR since glContextRecreated %b, "
+                     "renderingParamsChanged %b",
+                     CTX.renderingParamsChanged,
+                     CTX.glContextRecreated);
+                GL(glGenTextures(2, CTX.lobbyTextures));
 
-            for (auto &lobbyTexture : CTX.lobbyTextures) {
-                GL(glBindTexture(GL_TEXTURE_2D, lobbyTexture));
-                GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-                GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-                GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-                GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
-                GL(glTexImage2D(GL_TEXTURE_2D,
-                                0,
-                                GL_RGB,
-                                CTX.screenWidth / 2,
-                                CTX.screenHeight,
-                                0,
-                                GL_RGB,
-                                GL_UNSIGNED_BYTE,
-                                nullptr));
+                for (auto &lobbyTexture: CTX.lobbyTextures) {
+                    GL(glBindTexture(GL_TEXTURE_2D, lobbyTexture));
+                    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+                    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+                    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+                    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+                    GL(glTexImage2D(GL_TEXTURE_2D,
+                                    0,
+                                    GL_RGB,
+                                    CTX.screenWidth / 2,
+                                    CTX.screenHeight,
+                                    0,
+                                    GL_RGB,
+                                    GL_UNSIGNED_BYTE,
+                                    nullptr));
+                }
+
+                const uint32_t *targetViews[2] = {(uint32_t *) &CTX.lobbyTextures[0],
+                                                  (uint32_t *) &CTX.lobbyTextures[1]};
+                alvr_resume_opengl(CTX.screenWidth / 2, CTX.screenHeight, targetViews, 1, true);
             }
-
-            const uint32_t *targetViews[2] = {(uint32_t *) &CTX.lobbyTextures[0],
-                                              (uint32_t *) &CTX.lobbyTextures[1]};
-            alvr_resume_opengl(CTX.screenWidth / 2, CTX.screenHeight, targetViews, 1, true);
-
             CTX.renderingParamsChanged = false;
             CTX.glContextRecreated = false;
         }
@@ -481,7 +503,9 @@ extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_render
             viewsDesc.bottom_v = 0.0;
         }
 
-        if (CTX.streaming) {
+        if (CTX.passthroughInfo.enabled) {
+            passthrough_render(&(CTX.passthroughInfo), viewsDescs);
+        } else if (CTX.streaming) {
             void *streamHardwareBuffer = nullptr;
 
             AlvrViewParams dummyViewParams;

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp
@@ -11,8 +11,8 @@
 #include <vector>
 
 #include "nlohmann/json.hpp"
-#include "utils.h"
 #include "passthrough.h"
+#include "utils.h"
 
 using namespace nlohmann;
 
@@ -341,7 +341,7 @@ extern "C" JNIEXPORT void JNICALL Java_viritualisres_phonevr_ALVRActivity_render
                      CTX.glContextRecreated);
                 GL(glGenTextures(2, CTX.lobbyTextures));
 
-                for (auto &lobbyTexture: CTX.lobbyTextures) {
+                for (auto &lobbyTexture : CTX.lobbyTextures) {
                     GL(glBindTexture(GL_TEXTURE_2D, lobbyTexture));
                     GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
                     GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
@@ -1,0 +1,196 @@
+#include "alvr_client_core.h"
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+#include <vector>
+
+#include "passthrough.h"
+#include "utils.h"
+
+GLuint LoadGLShader(GLenum type, const char *shader_source) {
+    GLuint shader = GL(glCreateShader(type));
+
+    GL(glShaderSource(shader, 1, &shader_source, nullptr));
+    GL(glCompileShader(shader));
+
+    // Get the compilation status.
+    GLint compile_status;
+    GL(glGetShaderiv(shader, GL_COMPILE_STATUS, &compile_status));
+
+    // If the compilation failed, delete the shader and show an error.
+    if (compile_status == 0) {
+        GLint info_len = 0;
+        GL(glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &info_len));
+        if (info_len == 0) {
+            return 0;
+        }
+
+        std::vector<char> info_string(info_len);
+        GL(glGetShaderInfoLog(shader, info_string.size(), nullptr, info_string.data()));
+        // LOGE("Could not compile shader of type %d: %s", type, info_string.data());
+        GL(glDeleteShader(shader));
+        return 0;
+    } else {
+        return shader;
+    }
+}
+
+namespace {
+    // Simple shaders to render camera Texture files without any lighting.
+    constexpr const char *camVertexShader =
+        R"glsl(
+    uniform mat4 u_MVP;
+    attribute vec4 a_Position;
+    attribute vec2 a_UV;
+    varying vec2 v_UV;
+
+    void main() {
+      v_UV = a_UV;
+      gl_Position = a_Position;
+    })glsl";
+
+    constexpr const char *camFragmentShader =
+        R"glsl(
+    #extension GL_OES_EGL_image_external : require
+    precision mediump float;
+    varying vec2 v_UV;
+    uniform samplerExternalOES sTexture;
+    void main() {
+        gl_FragColor = texture2D(sTexture, v_UV);
+    })glsl";
+
+    static int passthroughProgram_ = 0;
+    static int texturePositionParam_ = 0;
+    static int textureUvParam_ = 0;
+    static int textureMvpParam_ = 0;
+
+    float passthroughTexCoords[] = {0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0};
+}   // namespace
+
+void passthrough_createPlane(PassthroughInfo *info) {
+    float size = info->passthroughSize;
+    float x0 = -size, y0 = size;    // Top left
+    float x1 = size, y1 = size;     // Top right
+    float x2 = size, y2 = -size;    // Bottom right
+    float x3 = -size, y3 = -size;   // Bottom left
+
+    info->passthroughVertices[0] = x3;
+    info->passthroughVertices[1] = y3;
+    info->passthroughVertices[2] = x2;
+    info->passthroughVertices[3] = y2;
+    info->passthroughVertices[4] = x0;
+    info->passthroughVertices[5] = y0;
+    info->passthroughVertices[6] = x1;
+    info->passthroughVertices[7] = y1;
+}
+
+GLuint passthrough_init(PassthroughInfo *info) {
+    const int obj_vertex_shader = LoadGLShader(GL_VERTEX_SHADER, camVertexShader);
+    const int obj_fragment_shader = LoadGLShader(GL_FRAGMENT_SHADER, camFragmentShader);
+
+    passthroughProgram_ = GL(glCreateProgram());
+    GL(glAttachShader(passthroughProgram_, obj_vertex_shader));
+    GL(glAttachShader(passthroughProgram_, obj_fragment_shader));
+    GL(glLinkProgram(passthroughProgram_));
+
+    GL(glUseProgram(passthroughProgram_));
+    texturePositionParam_ = GL(glGetAttribLocation(passthroughProgram_, "a_Position"));
+    textureUvParam_ = GL(glGetAttribLocation(passthroughProgram_, "a_UV"));
+    textureMvpParam_ = GL(glGetUniformLocation(passthroughProgram_, "u_MVP"));
+
+    GL(glGenTextures(1, &(info->cameraTexture)));
+    GL(glActiveTexture(GL_TEXTURE0));
+
+    GL(glBindTexture(GL_TEXTURE_EXTERNAL_OES, info->cameraTexture));
+    GL(glTexParameterf(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+    GL(glTexParameterf(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+    GL(glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+    GL(glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+
+    return info->cameraTexture;
+}
+
+void passthrough_cleanup(PassthroughInfo *info) {
+    if (info->passthroughDepthRenderBuffer != 0) {
+        GL(glDeleteRenderbuffers(1, &(info->passthroughDepthRenderBuffer)));
+        info->passthroughDepthRenderBuffer = 0;
+    }
+    if (info->passthroughFramebuffer != 0) {
+        GL(glDeleteFramebuffers(1, &info->passthroughFramebuffer));
+        info->passthroughFramebuffer = 0;
+    }
+    if (info->passthroughTexture != 0) {
+        GL(glDeleteTextures(1, &(info->passthroughTexture)));
+        info->passthroughTexture = 0;
+    }
+}
+
+void passthrough_setup(PassthroughInfo *info) {
+    // Create render texture.
+    GL(glGenTextures(1, &(info->passthroughTexture)));
+    GL(glBindTexture(GL_TEXTURE_2D, info->passthroughTexture));
+    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+    GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+
+    GL(glTexImage2D(GL_TEXTURE_2D,
+                 0,
+                 GL_RGB,
+                 *(info->screenWidth),
+                 *(info->screenHeight),
+                 0,
+                 GL_RGB,
+                 GL_UNSIGNED_BYTE,
+                 0));
+
+    // Generate depth buffer to perform depth test.
+    GL(glGenRenderbuffers(1, &(info->passthroughDepthRenderBuffer)));
+    GL(glBindRenderbuffer(GL_RENDERBUFFER, info->passthroughDepthRenderBuffer));
+    GL(glRenderbufferStorage(
+        GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, *(info->screenWidth), *(info->screenHeight)));
+
+    // Create render target.
+    GL(glGenFramebuffers(1, &(info->passthroughFramebuffer)));
+    GL(glBindFramebuffer(GL_FRAMEBUFFER, info->passthroughFramebuffer));
+    GL(glFramebufferTexture2D(
+        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, info->passthroughTexture, 0));
+    GL(glFramebufferRenderbuffer(
+        GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, info->passthroughDepthRenderBuffer));
+}
+
+void passthrough_render(PassthroughInfo *info, CardboardEyeTextureDescription viewsDescs[]) {
+    GL(glBindFramebuffer(GL_FRAMEBUFFER, info->passthroughFramebuffer));
+
+    GL(glEnable(GL_DEPTH_TEST));
+    GL(glEnable(GL_CULL_FACE));
+    GL(glDisable(GL_SCISSOR_TEST));
+    GL(glEnable(GL_BLEND));
+    GL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+    GL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+
+    // Draw Passthrough video for each eye
+    for (int eye = 0; eye < 2; ++eye) {
+        GL(glViewport(eye == kLeft ? 0 : *(info->screenWidth) / 2,
+                   0,
+                   *(info->screenWidth) / 2,
+                   *(info->screenHeight)));
+
+        GL(glUseProgram(passthroughProgram_));
+        GL(glActiveTexture(GL_TEXTURE0));
+        GL(glBindTexture(GL_TEXTURE_EXTERNAL_OES, info->cameraTexture));
+
+        // Draw Mesh
+        GL(glEnableVertexAttribArray(texturePositionParam_));
+        GL(glVertexAttribPointer(
+                texturePositionParam_, 2, GL_FLOAT, false, 0, info->passthroughVertices));
+        GL(glEnableVertexAttribArray(textureUvParam_));
+        GL(glVertexAttribPointer(textureUvParam_, 2, GL_FLOAT, false, 0, passthroughTexCoords));
+
+        GL(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
+
+        viewsDescs[eye].left_u = 0.5 * eye;          // 0 for left, 0.5 for right
+        viewsDescs[eye].right_u = 0.5 + 0.5 * eye;   // 0.5 for left, 1.0 for right
+    }
+    viewsDescs[0].texture = info->passthroughTexture;
+    viewsDescs[1].texture = info->passthroughTexture;
+}

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
@@ -3,8 +3,8 @@
 #include <GLES2/gl2ext.h>
 #include <vector>
 
-#include "passthrough.h"
 #include "utils.h"
+#include "passthrough.h"
 
 GLuint LoadGLShader(GLenum type, const char *shader_source) {
     GLuint shader = GL(glCreateShader(type));

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
@@ -1,6 +1,6 @@
 #include "alvr_client_core.h"
-#include <GLES3/gl3.h>
 #include <GLES2/gl2ext.h>
+#include <GLES3/gl3.h>
 #include <vector>
 
 #include "passthrough.h"

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
@@ -3,8 +3,8 @@
 #include <GLES2/gl2ext.h>
 #include <vector>
 
-#include "utils.h"
 #include "passthrough.h"
+#include "utils.h"
 
 GLuint LoadGLShader(GLenum type, const char *shader_source) {
     GLuint shader = GL(glCreateShader(type));
@@ -134,14 +134,14 @@ void passthrough_setup(PassthroughInfo *info) {
     GL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
 
     GL(glTexImage2D(GL_TEXTURE_2D,
-                 0,
-                 GL_RGB,
-                 *(info->screenWidth),
-                 *(info->screenHeight),
-                 0,
-                 GL_RGB,
-                 GL_UNSIGNED_BYTE,
-                 0));
+                    0,
+                    GL_RGB,
+                    *(info->screenWidth),
+                    *(info->screenHeight),
+                    0,
+                    GL_RGB,
+                    GL_UNSIGNED_BYTE,
+                    0));
 
     // Generate depth buffer to perform depth test.
     GL(glGenRenderbuffers(1, &(info->passthroughDepthRenderBuffer)));
@@ -171,9 +171,9 @@ void passthrough_render(PassthroughInfo *info, CardboardEyeTextureDescription vi
     // Draw Passthrough video for each eye
     for (int eye = 0; eye < 2; ++eye) {
         GL(glViewport(eye == kLeft ? 0 : *(info->screenWidth) / 2,
-                   0,
-                   *(info->screenWidth) / 2,
-                   *(info->screenHeight)));
+                      0,
+                      *(info->screenWidth) / 2,
+                      *(info->screenHeight)));
 
         GL(glUseProgram(passthroughProgram_));
         GL(glActiveTexture(GL_TEXTURE0));
@@ -182,7 +182,7 @@ void passthrough_render(PassthroughInfo *info, CardboardEyeTextureDescription vi
         // Draw Mesh
         GL(glEnableVertexAttribArray(texturePositionParam_));
         GL(glVertexAttribPointer(
-                texturePositionParam_, 2, GL_FLOAT, false, 0, info->passthroughVertices));
+            texturePositionParam_, 2, GL_FLOAT, false, 0, info->passthroughVertices));
         GL(glEnableVertexAttribArray(textureUvParam_));
         GL(glVertexAttribPointer(textureUvParam_, 2, GL_FLOAT, false, 0, passthroughTexCoords));
 

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.cpp
@@ -1,6 +1,8 @@
 #include "alvr_client_core.h"
-#include <GLES2/gl2ext.h>
+// clang-format off
 #include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+// clang-format on
 #include <vector>
 
 #include "passthrough.h"

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.h
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.h
@@ -1,0 +1,29 @@
+#ifndef PHONEVR_PASSTHROUGH_H
+
+#include "cardboard.h"
+
+struct PassthroughInfo {
+    bool enabled = false;
+
+    GLuint cameraTexture = 0;
+    GLuint passthroughTexture = 0;
+
+    GLuint passthroughDepthRenderBuffer = 0;
+    GLuint passthroughFramebuffer = 0;
+
+    float passthroughVertices[8];
+    float passthroughSize = 1.0;
+
+    int *screenWidth = 0;
+    int *screenHeight = 0;
+};
+
+void passthrough_createPlane(PassthroughInfo *info);
+GLuint passthrough_init(PassthroughInfo *info);
+void passthrough_cleanup(PassthroughInfo *info);
+void passthrough_setup(PassthroughInfo *info);
+void passthrough_render(PassthroughInfo *info, CardboardEyeTextureDescription viewDescs[]);
+
+#define PHONEVR_PASSTHROUGH_H
+
+#endif   // PHONEVR_PASSTHROUGH_H

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.h
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/passthrough.h
@@ -1,4 +1,5 @@
 #ifndef PHONEVR_PASSTHROUGH_H
+#define PHONEVR_PASSTHROUGH_H
 
 #include "cardboard.h"
 
@@ -23,7 +24,5 @@ GLuint passthrough_init(PassthroughInfo *info);
 void passthrough_cleanup(PassthroughInfo *info);
 void passthrough_setup(PassthroughInfo *info);
 void passthrough_render(PassthroughInfo *info, CardboardEyeTextureDescription viewDescs[]);
-
-#define PHONEVR_PASSTHROUGH_H
 
 #endif   // PHONEVR_PASSTHROUGH_H

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
@@ -12,7 +12,7 @@
 
 const char LOG_TAG[] = "ALVR_PVR_NATIVE";
 
-void log(AlvrLogLevel level,
+static void log(AlvrLogLevel level,
          const char *FILE_NAME,
          unsigned int LINE_NO,
          const char *FUNC,

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
@@ -13,11 +13,11 @@
 const char LOG_TAG[] = "ALVR_PVR_NATIVE";
 
 static void log(AlvrLogLevel level,
-         const char *FILE_NAME,
-         unsigned int LINE_NO,
-         const char *FUNC,
-         const char *format,
-         ...) {
+                const char *FILE_NAME,
+                unsigned int LINE_NO,
+                const char *FUNC,
+                const char *format,
+                ...) {
     va_list args;
     va_start(args, format);
 

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/ALVRActivity.java
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/ALVRActivity.java
@@ -144,10 +144,7 @@ public class ALVRActivity extends AppCompatActivity
         pref = PreferenceManager.getDefaultSharedPreferences(this);
         passthrough =
                 new Passthrough(
-                        pref,
-                        (SensorManager) getSystemService(SENSOR_SERVICE),
-                        width,
-                        height);
+                        pref, (SensorManager) getSystemService(SENSOR_SERVICE), width, height);
     }
 
     @Override

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/GraphAdapter.java
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/GraphAdapter.java
@@ -1,0 +1,104 @@
+/* (C)2024 */
+package viritualisres.phonevr;
+
+import ir.mahdiparastesh.hellocharts.model.Axis;
+import ir.mahdiparastesh.hellocharts.model.Line;
+import ir.mahdiparastesh.hellocharts.model.LineChartData;
+import ir.mahdiparastesh.hellocharts.model.PointValue;
+import ir.mahdiparastesh.hellocharts.model.Viewport;
+import ir.mahdiparastesh.hellocharts.util.ChartUtils;
+import ir.mahdiparastesh.hellocharts.view.LineChartView;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GraphAdapter {
+
+    private final LineChartView chart;
+    private List<Long> timestamps = new ArrayList<>();
+    private Map<String, List<Float>> lines = new HashMap<>();
+    private List<String> keyOrder = new ArrayList<>();
+    private List<Integer> color = new ArrayList<>();
+    private int len;
+    private float max = 10.f;
+
+    public GraphAdapter(int len, LineChartView chart) {
+        this.len = len;
+        this.chart = chart;
+    }
+
+    private int checkTimestamp(Long ts) {
+        if (!timestamps.contains(ts)) {
+            timestamps.add(ts);
+            if (timestamps.size() > this.len) {
+                timestamps.remove(0);
+            }
+        }
+        return timestamps.indexOf(ts) + 1;
+    }
+
+    private void resetViewport() {
+        Viewport v = new Viewport(chart.getMaximumViewport());
+        v.bottom = 0;
+        v.top = (int) max;
+        v.left = 0;
+        v.right = this.len - 1;
+        chart.setMaximumViewport(v);
+        chart.setCurrentViewport(v);
+    }
+
+    public void addValue(Long ts, String name, Float value) {
+        int position = checkTimestamp(ts);
+        if (!lines.containsKey(name)) {
+            lines.put(name, new ArrayList<>());
+            keyOrder.add(name);
+            color.add(ChartUtils.pickColor());
+        }
+        List<Float> list = lines.get(name);
+        list.add(value);
+        while (list.size() < position) {
+            list.add(0, 0.f);
+        }
+        if (list.size() > position) {
+            list.remove(0);
+        }
+    }
+
+    public void addValue(Long ts, String name, boolean value) {
+        if (value) {
+            addValue(ts, name, max);
+        } else {
+            addValue(ts, name, 0.f);
+        }
+    }
+
+    public void refresh() {
+        List<Line> _lines = new ArrayList<>();
+        for (int j = 0; j < keyOrder.size(); ++j) {
+            String name = keyOrder.get(j);
+            List<Float> elems = lines.get(name);
+            List<PointValue> values = new ArrayList<>();
+            for (int i = 0; i < elems.size(); ++i) {
+                values.add(new PointValue(i, elems.get(i)));
+            }
+            Line line = new Line(values);
+            line.setColor(color.get(j));
+            line.setHasPoints(false);
+            _lines.add(line);
+        }
+        LineChartData data = new LineChartData(_lines);
+
+        Axis axisX = new Axis();
+        Axis axisY = new Axis().setHasLines(true);
+        axisX.setName("Time");
+        axisY.setName("Values");
+
+        data.setAxisXBottom(axisX);
+        data.setAxisYLeft(axisY);
+
+        data.setBaseValue(Float.NEGATIVE_INFINITY);
+        chart.setLineChartData(data);
+        resetViewport();
+    }
+}

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/Passthrough.java
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/Passthrough.java
@@ -1,0 +1,389 @@
+/* (C)2024 */
+package viritualisres.phonevr;
+
+import android.content.SharedPreferences;
+import android.graphics.SurfaceTexture;
+import android.hardware.Camera;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.os.Build;
+import android.util.Log;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+public class Passthrough implements SensorEventListener {
+
+    static {
+        System.loadLibrary("native-lib");
+    }
+
+    private static final String TAG = Passthrough.class.getSimpleName() + "-Java";
+
+    private Camera mCamera = null;
+
+    private SurfaceTexture mTexture = null;
+    private Camera.Size mPreviewSize = null;
+
+    private final SharedPreferences mPref;
+
+    private final SensorManager mSensorManager;
+
+    private final int displayWidth;
+
+    private final int displayHeight;
+
+    private Sensor mAccelerometer = null;
+
+    private long timestamp = 0;
+
+    private long timestampAfterCandidate = 0;
+
+    private long passthroughDelayInMs = 600;
+
+    private float detectionLowerBound = 0.8f;
+
+    private float detectionUpperBound = 4f;
+
+    private final List<Float>[] accelStore =
+            new List[] {new ArrayList<>(), new ArrayList<>(), new ArrayList<>()};
+
+    private int halfSize = 0;
+
+    private boolean triggerIsSet = false;
+
+    private final List<Float> cumSums = new ArrayList<>();
+
+    public Passthrough(
+            SharedPreferences pref,
+            SensorManager sensorManager,
+            int displayWidth,
+            int displayHeight) {
+        this.displayWidth = displayWidth;
+        this.displayHeight = displayHeight;
+        mPref = pref;
+        mSensorManager = sensorManager;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mAccelerometer =
+                    mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER_UNCALIBRATED);
+        }
+        if (mAccelerometer == null) {
+            mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+        }
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent event) {
+        if (timestamp == 0) {
+            timestamp = event.timestamp;
+        }
+
+        if (timestampAfterCandidate == 0) {
+            timestampAfterCandidate = event.timestamp;
+        }
+
+        boolean initialFull = event.timestamp - timestamp > passthroughDelayInMs * 1000000L;
+        boolean afterCandidateFull =
+                event.timestamp - timestampAfterCandidate > passthroughDelayInMs * 1000000L;
+
+        // gather data for passthrough_delay_ms, we get a data point approx. each 60ms
+        for (int i = 0; i < accelStore.length; ++i) {
+            // derivative, absolute
+            accelStore[i].add(event.values[i]);
+
+            if (initialFull) {
+                // remove the first element to only store the last X elements
+                accelStore[i].remove(0);
+                if (halfSize == 0) {
+                    halfSize = accelStore[0].size() / 2;
+                }
+                // check if half size has at least 3 data points
+                if (halfSize < 4) {
+                    accelStore[i].clear();
+                    timestamp = 0;
+                    halfSize = 0;
+                }
+            }
+        }
+
+        if (halfSize > 0) {
+            // Calculate derivative and absolute values
+            List<Float>[] accelAbs =
+                    new List[] {new ArrayList<>(), new ArrayList<>(), new ArrayList<>()};
+            for (int axis = 0; axis < accelStore.length; ++axis) {
+                for (int i = 1; i < accelStore[axis].size(); ++i) {
+                    accelAbs[axis].add(
+                            Math.abs(accelStore[axis].get(i) - accelStore[axis].get(i - 1)));
+                }
+            }
+
+            // get the mean for each axis and sum them up
+            float[] axisMean = new float[] {0.0f, 0.0f, 0.0f};
+            for (int i = 0; i < accelAbs.length; ++i) {
+                for (int j = 0; j < accelAbs[i].size(); ++j) {
+                    axisMean[i] += accelAbs[i].get(j);
+                }
+                axisMean[i] /= accelAbs[i].size();
+            }
+            float sumMean = axisMean[0] + axisMean[1] + axisMean[2];
+            cumSums.add(sumMean);
+
+            if (cumSums.size() < accelAbs[0].size()) {
+                return;
+            } else {
+                // only store the last X elements
+                cumSums.remove(0);
+            }
+
+            if (!afterCandidateFull) {
+                // if a potential passthrough_change event is found,
+                // check if the device does not move much anymore
+                if (!triggerIsSet && sumMean < detectionLowerBound) {
+                    triggerIsSet = true;
+                    // if passthroughMode not already changed... change it
+                    changePassthroughMode();
+                }
+            } else {
+                triggerIsSet = false;
+                // here we check for potential passthrough_change events
+                // these may occur on any axis
+                for (List<Float> elem : accelAbs) {
+                    // we look at two halves of the passthrough_delay
+                    // we check:
+                    // - if in the first and second half is a real peak
+                    // - whether the peaks are in the bounds
+                    // - if the summed mean is in the bounds
+                    // - if the first summed mean is below lower_bound
+                    //   (to assure a resting stage before the triggering)
+                    // - if the second maximum is decending under the lower bound until curr value
+                    // If all is fulfilled we consider this a potential passthrough_change event.
+                    // The sum must then decend under lower bound until passthrough_delay
+                    int middle = halfSize - 1;
+                    List<Float> t1 = elem.subList(0, halfSize);
+                    List<Float> t2 = elem.subList(middle, elem.size());
+
+                    float max1 = Collections.max(t1);
+                    float max2 = Collections.max(t2);
+
+                    if (max1 - t1.get(0) < detectionLowerBound
+                            || max1 - t1.get(t1.size() - 1) < detectionLowerBound
+                            || max2 - t2.get(0) < detectionLowerBound
+                            || max2 - t2.get(t2.size() - 1) < detectionLowerBound
+                            || max1 < detectionLowerBound
+                            || max1 > detectionUpperBound
+                            || max2 < detectionLowerBound
+                            || max2 > detectionUpperBound
+                            || sumMean < detectionLowerBound
+                            || sumMean > detectionUpperBound) {
+                        continue;
+                    }
+
+                    int end2 = 0;
+                    for (int i = 0; i < t2.size(); ++i) {
+                        if (t2.get(i) == max2) {
+                            end2 = i;
+                        }
+                        if (end2 > 0) {
+                            if (t2.get(i) < detectionLowerBound) {
+                                end2 = i;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (cumSums.get(0) < Math.max(detectionLowerBound - 0.3f, 0.5f)
+                            && t2.get(end2) < max2) {
+                        timestampAfterCandidate = event.timestamp;
+                        break;
+                    }
+                }
+            }
+        }
+
+        Log.v(
+                TAG + "-AccSensor",
+                String.format(
+                        (Locale) null,
+                        "%d: [%f, %f, %f]",
+                        event.timestamp,
+                        event.values[0],
+                        event.values[1],
+                        event.values[2]));
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {}
+
+    protected void onResume() {
+        SharedPreferences.Editor edit = mPref.edit();
+        edit.putBoolean("passthrough", false);
+        edit.apply();
+
+        timestamp = 0;
+        halfSize = 0;
+        if (mPref.getBoolean("passthrough_tap", true)) {
+            try {
+                passthroughDelayInMs = Long.parseLong(mPref.getString("passthrough_delay", "600"));
+            } catch (Exception e) {
+                passthroughDelayInMs = 600;
+            }
+            try {
+                detectionLowerBound = Float.parseFloat(mPref.getString("passthrough_lower", "0.8"));
+            } catch (Exception e) {
+                detectionLowerBound = 0.8f;
+            }
+            try {
+                detectionUpperBound = Float.parseFloat(mPref.getString("passthrough_upper", "4"));
+            } catch (Exception e) {
+                detectionUpperBound = 4.f;
+            }
+
+            if (mAccelerometer != null) {
+                mSensorManager.registerListener(
+                        this, mAccelerometer, SensorManager.SENSOR_DELAY_UI);
+            }
+        } else {
+            mSensorManager.unregisterListener(this);
+        }
+    }
+
+    protected void setPassthroughMode(boolean passthrough) {
+        if (passthrough) {
+            int w = displayWidth / 2;
+            int h = displayHeight;
+            if (displayWidth < displayHeight) {
+                w = displayHeight / 2;
+                h = displayWidth;
+            }
+            openCamera(-1, w, h, mPref.getBoolean("passthrough_recording", true));
+
+            float size = 0.5f;
+            try {
+                size = Float.parseFloat(mPref.getString("passthrough_fraction", "0.5"));
+            } catch (RuntimeException e) {
+            }
+
+            setPassthroughSizeNative(size);
+        }
+        setPassthroughActiveNative(passthrough);
+
+        if (passthrough) {
+            startPreview();
+        } else {
+            releaseCamera();
+        }
+    }
+
+    protected void changePassthroughMode() {
+        boolean pt = !mPref.getBoolean("passthrough", false);
+        SharedPreferences.Editor edit = mPref.edit();
+        edit.putBoolean("passthrough", pt);
+        edit.apply();
+        setPassthroughMode(pt);
+    }
+
+    public void createTexture(int textureID) {
+        mTexture = new SurfaceTexture(textureID);
+    }
+
+    public void openCamera(int camNr, int desiredWidth, int desiredHeight, boolean recordingHint) {
+        if (mCamera != null) {
+            // TODO maybe print only a warning
+            throw new RuntimeException("Camera already initialized");
+        }
+        Camera.CameraInfo info = new Camera.CameraInfo();
+        // TODO add possibility to choose camera
+        if (camNr < 0) {
+            int numCameras = Camera.getNumberOfCameras();
+            for (int i = 0; i < numCameras; ++i) {
+                Camera.getCameraInfo(i, info);
+                if (info.facing == Camera.CameraInfo.CAMERA_FACING_BACK) {
+                    mCamera = Camera.open(i);
+                    break;
+                }
+            }
+            if (mCamera == null) {
+                // TODO log message "No back-facing camera found; opening default"
+                mCamera = Camera.open(); // open default
+            }
+        } else {
+            mCamera = Camera.open(camNr);
+        }
+        if (mCamera == null) {
+            throw new RuntimeException("Unable to open camera");
+        }
+        // TODO the size stuff
+        Camera.Parameters params = mCamera.getParameters();
+        List<Camera.Size> choices = params.getSupportedPreviewSizes();
+        mPreviewSize = chooseOptimalSize(choices, desiredWidth, desiredHeight);
+        Log.d(TAG, "PreviewSize: " + mPreviewSize.width + "x" + mPreviewSize.height);
+        params.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
+        params.setRecordingHint(recordingHint); // Can increase fps in passthrough mode
+        mCamera.setParameters(params);
+    }
+
+    private Camera.Size chooseOptimalSize(List<Camera.Size> choices, int width, int height) {
+        Integer minSize = Integer.max(Integer.min(width, height), 320);
+
+        // Collect the supported resolutions that are at least as big as the preview Surface
+        ArrayList<Camera.Size> bigEnough = new ArrayList<>();
+        for (Camera.Size option : choices) {
+            if (option.width == width && option.height == height) {
+                return option;
+            }
+            if (option.height >= minSize && option.width >= minSize) {
+                bigEnough.add(option);
+            }
+        }
+
+        Comparator<Camera.Size> comp = (a, b) -> (a.width * a.height) - (b.width * b.width);
+        // Pick the smallest of those, assuming we found any
+        if (bigEnough.size() > 0) {
+            return Collections.min(bigEnough, comp);
+        } else {
+            return choices.get(0);
+        }
+    }
+
+    public void releaseCamera() {
+        if (mCamera != null) {
+            mCamera.setPreviewCallback(null);
+            mCamera.stopPreview();
+            mCamera.release();
+            mCamera = null;
+        }
+    }
+
+    public void startPreview() {
+        if (mCamera != null) {
+            // Log.d(TAG, "starting camera preview")
+            try {
+                mCamera.setPreviewTexture(mTexture);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            mCamera.startPreview();
+        }
+    }
+
+    public void onPause() {
+        mSensorManager.unregisterListener(this);
+        setPassthroughActiveNative(false);
+        releaseCamera();
+    }
+
+    public void update() {
+        if (mTexture != null) {
+            mTexture.updateTexImage();
+        }
+    }
+
+    private native void setPassthroughSizeNative(float size);
+
+    private native void setPassthroughActiveNative(boolean activate);
+}

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/PassthroughSettingsActivity.java
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/PassthroughSettingsActivity.java
@@ -1,10 +1,27 @@
 /* (C)2024 */
 package viritualisres.phonevr;
 
+import android.annotation.SuppressLint;
 import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.PreferenceViewHolder;
+import androidx.recyclerview.widget.RecyclerView;
+import ir.mahdiparastesh.hellocharts.model.Axis;
+import ir.mahdiparastesh.hellocharts.model.Line;
+import ir.mahdiparastesh.hellocharts.model.LineChartData;
+import ir.mahdiparastesh.hellocharts.model.PointValue;
+import ir.mahdiparastesh.hellocharts.model.Viewport;
+import ir.mahdiparastesh.hellocharts.util.ChartUtils;
+import ir.mahdiparastesh.hellocharts.view.LineChartView;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PassthroughSettingsActivity extends AppCompatActivity {
 
@@ -25,9 +42,94 @@ public class PassthroughSettingsActivity extends AppCompatActivity {
     }
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
+        private final int numberOfLines = 4;
+        private final int numberOfPoints = 12;
+        private LineChartView chart = null;
+
+        float[][] randomNumbersTab = new float[numberOfLines][numberOfPoints];
+
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             setPreferencesFromResource(R.xml.passthrough_settings, rootKey);
+        }
+
+        @NonNull
+        @SuppressLint("RestrictedApi")
+        @Override
+        protected RecyclerView.Adapter<PreferenceViewHolder> onCreateAdapter(
+                PreferenceScreen pref) {
+            return new PreferenceGroupAdapter(pref) {
+                @NonNull
+                public PreferenceViewHolder onCreateViewHolder(
+                        @NonNull ViewGroup parent, int viewType) {
+                    PreferenceViewHolder holder = super.onCreateViewHolder(parent, viewType);
+                    View customLayout = holder.itemView;
+                    if (customLayout.getId() == R.id.chartLayout) {
+                        chart = customLayout.findViewById(R.id.chart);
+                        generateValues();
+                        generateData(chart);
+                        resetViewport(chart);
+                    }
+                    return holder;
+                }
+            };
+        }
+
+        private void generateValues() {
+            for (int i = 0; i < numberOfLines; ++i) {
+                for (int j = 0; j < numberOfPoints; ++j) {
+                    randomNumbersTab[i][j] = (float) Math.random() * 100f;
+                }
+            }
+        }
+
+        private void generateData(LineChartView chart) {
+            List<Line> lines = new ArrayList<>();
+            for (int i = 0; i < numberOfLines; ++i) {
+
+                List<PointValue> values = new ArrayList<>();
+                for (int j = 0; j < numberOfPoints; ++j) {
+                    values.add(new PointValue(j, randomNumbersTab[i][j]));
+                }
+
+                Line line = new Line(values);
+                line.setColor(ChartUtils.COLORS[i]);
+                // line.setShape(shape);
+                // line.setCubic(isCubic);
+                // line.setFilled(isFilled);
+                // line.setHasLabels(hasLabels);
+                // line.setHasLabelsOnlyForSelected(hasLabelForSelected);
+                // line.setHasLines(hasLines);
+                // line.setHasPoints(hasPoints);
+                // line.setHasGradientToTransparent(hasGradientToTransparent);
+                // if (pointsHaveDifferentColor)
+                //    line.setPointColor(ChartUtils.COLORS[(i + 1) % ChartUtils.COLORS.length]);
+                lines.add(line);
+            }
+
+            LineChartData data = new LineChartData(lines);
+
+            Axis axisX = new Axis();
+            Axis axisY = new Axis().setHasLines(true);
+            axisX.setName("Axis X");
+            axisY.setName("Axis Y");
+
+            data.setAxisXBottom(axisX);
+            data.setAxisYLeft(axisY);
+
+            data.setBaseValue(Float.NEGATIVE_INFINITY);
+            chart.setLineChartData(data);
+        }
+
+        private void resetViewport(LineChartView chart) {
+            // Reset viewport height range to (0,100)
+            final Viewport v = new Viewport(chart.getMaximumViewport());
+            v.bottom = 0;
+            v.top = 100;
+            v.left = 0;
+            v.right = numberOfPoints - 1;
+            chart.setMaximumViewport(v);
+            chart.setCurrentViewport(v);
         }
     }
 }

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/PassthroughSettingsActivity.java
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/PassthroughSettingsActivity.java
@@ -16,7 +16,6 @@ import androidx.preference.PreferenceManager;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.PreferenceViewHolder;
 import androidx.recyclerview.widget.RecyclerView;
-import ir.mahdiparastesh.hellocharts.view.LineChartView;
 
 public class PassthroughSettingsActivity extends AppCompatActivity {
 
@@ -43,7 +42,6 @@ public class PassthroughSettingsActivity extends AppCompatActivity {
     }
 
     public static class SettingsFragment extends PreferenceFragmentCompat {
-        private LineChartView chart = null;
         private Passthrough passthrough;
         private GraphAdapter graphAdapter;
 
@@ -68,8 +66,7 @@ public class PassthroughSettingsActivity extends AppCompatActivity {
                     PreferenceViewHolder holder = super.onCreateViewHolder(parent, viewType);
                     View customLayout = holder.itemView;
                     if (customLayout.getId() == R.id.chartLayout) {
-                        chart = customLayout.findViewById(R.id.chart);
-                        graphAdapter = new GraphAdapter(100, chart);
+                        graphAdapter = new GraphAdapter(100, customLayout);
                         passthrough = new Passthrough(sharedPref, sensorManager, 640, 480);
                         passthrough.onResume(graphAdapter);
                     }

--- a/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/PassthroughSettingsActivity.java
+++ b/code/mobile/android/PhoneVR/app/src/main/java/viritualisres/phonevr/PassthroughSettingsActivity.java
@@ -1,0 +1,33 @@
+/* (C)2024 */
+package viritualisres.phonevr;
+
+import android.os.Bundle;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.PreferenceFragmentCompat;
+
+public class PassthroughSettingsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_passthrough_settings);
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.settings, new SettingsFragment())
+                    .commit();
+        }
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+    public static class SettingsFragment extends PreferenceFragmentCompat {
+        @Override
+        public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+            setPreferencesFromResource(R.xml.passthrough_settings, rootKey);
+        }
+    }
+}

--- a/code/mobile/android/PhoneVR/app/src/main/res/layout/activity_passthrough_settings.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/layout/activity_passthrough_settings.xml
@@ -1,0 +1,10 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/settings"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+</LinearLayout>

--- a/code/mobile/android/PhoneVR/app/src/main/res/layout/chart_layout.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/layout/chart_layout.xml
@@ -4,9 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ir.mahdiparastesh.hellocharts.view.LineChartView
+    <com.github.mikephil.charting.charts.LineChart
         android:id="@+id/chart"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="match_parent" />
 
 </LinearLayout>

--- a/code/mobile/android/PhoneVR/app/src/main/res/layout/chart_layout.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/layout/chart_layout.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/chartLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ir.mahdiparastesh.hellocharts.view.LineChartView
+        android:id="@+id/chart"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/code/mobile/android/PhoneVR/app/src/main/res/menu/settings_menu.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/menu/settings_menu.xml
@@ -10,4 +10,11 @@
         android:id="@+id/max_brightness_toggle"
         android:title="@string/max_brightness"
         android:checkable="true"/>
+    <item
+        android:id="@+id/passthrough_settings"
+        android:title="@string/passthrough_settings" />
+    <item
+        android:id="@+id/passthrough"
+        android:checkable="true"
+        android:title="@string/passthrough" />
 </menu>

--- a/code/mobile/android/PhoneVR/app/src/main/res/values/arrays.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/values/arrays.xml
@@ -1,0 +1,12 @@
+<resources>
+    <!-- Reply Preference -->
+    <string-array name="reply_entries">
+        <item>Reply</item>
+        <item>Reply to all</item>
+    </string-array>
+
+    <string-array name="reply_values">
+        <item>reply</item>
+        <item>reply_all</item>
+    </string-array>
+</resources>

--- a/code/mobile/android/PhoneVR/app/src/main/res/values/strings.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/values/strings.xml
@@ -41,4 +41,18 @@
     <string name="switch_phonevr_server">Switch PhoneVR Server</string>
     <string name="remember_choice">Remember choice</string>
     <string name="max_brightness">Max Brightness</string>
+    <string name="title_activity_passthrough_settings">PassthroughSettingsActivity</string>
+    <string name="passthrough_fraction">Passthrough fraction</string>
+    <string name="passthrough_activate">Enable passthrough</string>
+    <string name="fraction_summary">The fraction how much the passthrough should contain of the image (between 0.0 and 1.0). This depends on the FOV of the camera, for narrow FOV a lower value might be better, so that objects don\'t look to close... Play around with this value.</string>
+    <string name="set_recording_hint">Set Recording Hint</string>
+    <string name="recording_hint_summary">If set to false the passthrough may have a greater FOV, but has less FPS which may cause motion sickness.</string>
+    <string name="experimental_double_tap_detection">Experimental Double-Tap detection</string>
+    <string name="double_tap_summary">If true passthrough can be switched through double-tap.</string>
+    <string name="double_tap_configuration">Double Tap Configuration</string>
+    <string name="delay_string">Delay in ms</string>
+    <string name="lower_bound">Lower Bound</string>
+    <string name="upper_bound">Upper Bound</string>
+    <string name="passthrough_settings">Passthrough Settings</string>
+    <string name="passthrough">Passthrough</string>
 </resources>

--- a/code/mobile/android/PhoneVR/app/src/main/res/values/strings.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="delay_string">Delay in ms</string>
     <string name="lower_bound">Lower Bound</string>
     <string name="upper_bound">Upper Bound</string>
+    <string name="double_tap_test_graph">Double Tap Test Graph</string>
     <string name="passthrough_settings">Passthrough Settings</string>
     <string name="passthrough">Passthrough</string>
 </resources>

--- a/code/mobile/android/PhoneVR/app/src/main/res/xml/passthrough_settings.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/xml/passthrough_settings.xml
@@ -1,0 +1,45 @@
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory app:title="@string/passthrough">
+
+        <EditTextPreference
+            app:defaultValue="0.5"
+            app:key="passthrough_fraction"
+            app:summary="@string/fraction_summary"
+            app:title="@string/passthrough_fraction"
+            app:useSimpleSummaryProvider="false" />
+        <SwitchPreference
+            app:key="passthrough_recording"
+            app:title="@string/set_recording_hint"
+            app:summary="@string/recording_hint_summary"
+            app:defaultValue="true"/>
+        <SwitchPreference
+            app:key="passthrough_tap"
+            app:title="@string/experimental_double_tap_detection"
+            app:summary="@string/double_tap_summary"
+            app:defaultValue="true"/>
+    </PreferenceCategory>
+    <PreferenceCategory app:title="@string/double_tap_configuration"
+        app:dependency="passthrough_tap">
+        <EditTextPreference
+            app:defaultValue="600"
+            app:dependency="passthrough_tap"
+            app:key="passthrough_delay"
+            app:title="@string/delay_string"
+            app:useSimpleSummaryProvider="true" />
+        <EditTextPreference
+            app:defaultValue="0.8"
+            app:dependency="passthrough_tap"
+            app:key="passthrough_lower"
+            app:title="@string/lower_bound"
+            app:useSimpleSummaryProvider="true" />
+        <EditTextPreference
+            app:defaultValue="4"
+            app:dependency="passthrough_tap"
+            app:key="passthrough_upper"
+            app:title="@string/upper_bound"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+
+
+</PreferenceScreen>

--- a/code/mobile/android/PhoneVR/app/src/main/res/xml/passthrough_settings.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/xml/passthrough_settings.xml
@@ -40,6 +40,16 @@
             app:title="@string/upper_bound"
             app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
+    <PreferenceCategory app:title="@string/double_tap_test_graph"
+        app:dependency="passthrough_tap">
+        <Preference
+            app:title="Test Chart"
+            app:dependency="passthrough_tap"
+            app:key="chart"
+            app:layout="@layout/chart_layout"
+            />
+    </PreferenceCategory>
+
 
 
 </PreferenceScreen>


### PR DESCRIPTION
I added a pass-through mode for ALVR... recently only tested in the lobby, but it should work while streaming (or should it?).

You can trigger the pass-through by double tapping on the side of your headset... this is a little experimental and needs some practice you should not hit too hard and also not to soft and you must start in a resting position.
Basically it detects 2 maxima of the derivative of the accelerator sensor signal on a predefined delay.
The algorithm is somewhat described in the comments of `onSensorChanged`
Or you can switch to passthrough in the settings menu (which is not really usable when the device is in the headset). Maybe it can be set to a predefined button (any suggestions?)

I also added a preference Activity, where you can tinker with the values for the pass-through or disable auto detection if it interferes while playing.

There are 2 more options in the Settings menu, the *Passthrough fraction* (the fraction of the view that should be filled with the camera image ... this is needed as some cameras hava a really narrow FOV so the passthrough would look kinda too close)  and the *set Recording Hint*, if set to false this can increase the FOV but usually also decreases the FPS which is kinda hard to look at, but maybe this is a no issue on newer smartphones.
