### PR TITLE
WIP: ARCore-based position tracking

### DIFF
--- a/code/mobile/android/PhoneVR/.gitignore
+++ b/code/mobile/android/PhoneVR/.gitignore
@@ -11,6 +11,7 @@
 /ALVR
 /cardboard
 /gvr-android-sdk-1.200
+/arcore-android-sdk-main
 /app/libraries
 /app/libraries_gvr
 

--- a/code/mobile/android/PhoneVR/app/CMakeLists.txt
+++ b/code/mobile/android/PhoneVR/app/CMakeLists.txt
@@ -19,6 +19,13 @@ add_library(native-lib-alvr SHARED
     ${LIB_SRC}
 )
 
+# Import the ARCore (Google Play Services for AR) library.
+add_library(arcore SHARED IMPORTED)
+set_target_properties(arcore PROPERTIES IMPORTED_LOCATION
+        ${ARCORE_LIBPATH}/${ANDROID_ABI}/libarcore_sdk_c.so
+        INTERFACE_INCLUDE_DIRECTORIES ${ARCORE_INCLUDE}
+)
+
 set(libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/libraries)
 set(alvr_build_dir ${CMAKE_CURRENT_SOURCE_DIR}/../ALVR/build/alvr_client_core)
 
@@ -31,10 +38,11 @@ target_include_directories(native-lib-alvr
     # ALVR Headers
     PUBLIC ${alvr_build_dir}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../cardboard
+    PUBLIC ${ARCORE_INCLUDE}
 )
 
 target_link_libraries(native-lib-alvr
-    log android EGL GLESv3 mediandk
+    log android EGL GLESv3 mediandk arcore
     ${alvr_build_dir}/${ANDROID_ABI}/libalvr_client_core.so
     ${libs_dir}/jni/${ANDROID_ABI}/libGfxPluginCardboard.so
 )

--- a/code/mobile/android/PhoneVR/app/build.gradle
+++ b/code/mobile/android/PhoneVR/app/build.gradle
@@ -7,6 +7,15 @@ apply plugin: 'com.google.gms.google-services'
 apply from: '../versioning.gradle'
 apply plugin: "com.diffplug.spotless"
 
+/*
+The arcore aar library contains the native shared libraries.  These are
+extracted before building to a temporary directory.
+ */
+def arcore_libpath = "${rootProject.layout.buildDirectory.get()}/arcore-native"
+
+// Create a configuration to mark which aars to extract .so files from
+configurations { natives }
+
 def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
@@ -50,6 +59,8 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++17 -fexceptions -frtti" //-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=ON"
+                arguments "-DARCORE_LIBPATH=${arcore_libpath}/jni",
+                          "-DARCORE_INCLUDE=${project.rootDir}/arcore-android-sdk-main/libraries/include"
             }
         }
 
@@ -174,6 +185,9 @@ dependencies {
     implementation 'androidx.camera:camera-lifecycle:1.3.4'
     implementation 'androidx.camera:camera-camera2:1.3.4'
 
+    implementation 'com.google.ar:core:1.46.0'
+    natives 'com.google.ar:core:1.46.0'
+
     def acraVersion = '5.7.0'
     implementation "ch.acra:acra-mail:$acraVersion"
     implementation "ch.acra:acra-dialog:$acraVersion"
@@ -197,6 +211,13 @@ task extractNdk(type: Copy)  {
             include "headers/vr/gvr/capi/**/*h"
             include "jni/**/libgvr_audio.so"
             include "jni/**/libgvr.so"
+        }
+    }
+    configurations.natives.files.each { f ->
+        copy {
+            from zipTree(f)
+            into arcore_libpath
+            include "jni/**/*"
         }
     }
 }

--- a/code/mobile/android/PhoneVR/app/src/gvr/CMakeLists.txt
+++ b/code/mobile/android/PhoneVR/app/src/gvr/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -std=c++17 -g")
 set(ANDROID_STL c++_static)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
 
-
 set(gvr_libs_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries_gvr)
 file(GLOB_RECURSE LIB_SRC
     ../../../../../../common/libs/ifaddrs/*.c

--- a/code/mobile/android/PhoneVR/app/src/main/AndroidManifest.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/AndroidManifest.xml
@@ -75,6 +75,8 @@
             android:screenOrientation="landscape"
             android:theme="@style/Theme.AppCompat.NoActionBar"
             android:launchMode="singleTop" />
+
+        <meta-data android:name="com.google.ar.core" android:value="optional" />
     </application>
 
 </manifest>

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
@@ -2,6 +2,7 @@
 #define PHONEVR_UTILS_H
 
 #include "alvr_client_core.h"
+#include "arcore_c_api.h"
 #include <GLES3/gl3.h>
 #include <android/log.h>
 #include <string>
@@ -86,5 +87,23 @@ static const char *GlErrorString(GLenum error) {
 #define GL(func)                                                                                   \
     func;                                                                                          \
     GLCheckErrors(__FILE__, __LINE__)
+
+/* Returns a pose having the translation of this pose but no rotation.
+ * The caller is responsible for freeing the original pose and the output pose.
+ * (C++ port of Pose.extractTranslation.) */
+static ArPose *ArPose_extractTranslation(ArSession *session, ArPose *in_pose) {
+    float raw_pose[7] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+    ArPose_getPoseRaw(session, in_pose, raw_pose);
+
+    raw_pose[0] = 0.f;
+    raw_pose[1] = 0.f;
+    raw_pose[2] = 0.f;
+    raw_pose[3] = 0.f;
+
+    ArPose *out_pose = nullptr;
+    ArPose_create(session, raw_pose, &out_pose);
+
+    return out_pose;
+}
 
 #endif   // PHONEVR_UTILS_H

--- a/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
+++ b/code/mobile/android/PhoneVR/app/src/main/cpp/utils.h
@@ -12,7 +12,7 @@
 
 const char LOG_TAG[] = "ALVR_PVR_NATIVE";
 
-void log(AlvrLogLevel level,
+static void log(AlvrLogLevel level,
          const char *FILE_NAME,
          unsigned int LINE_NO,
          const char *FUNC,

--- a/code/mobile/android/PhoneVR/app/src/main/res/values/strings.xml
+++ b/code/mobile/android/PhoneVR/app/src/main/res/values/strings.xml
@@ -42,4 +42,5 @@
     <string name="switch_phonevr_server">Switch PhoneVR Server</string>
     <string name="remember_choice">Remember choice</string>
     <string name="max_brightness">Max Brightness</string>
+    <string name="arcore_not_supported">Your device does not support ARCore; position tracking has been disabled</string>
 </resources>

--- a/code/mobile/android/PhoneVR/prepare-alvr-deps.sh
+++ b/code/mobile/android/PhoneVR/prepare-alvr-deps.sh
@@ -51,3 +51,7 @@ unzip download.zip
 rm download.zip
 fi
 
+rm -r "arcore-android-sdk"
+curl -sLS https://github.com/google-ar/arcore-android-sdk/archive/refs/heads/main.zip > download.zip
+unzip download.zip
+rm download.zip


### PR DESCRIPTION
Partially fixes #93, fixes #311.

Enable HMD position tracking based on ARCore's [motion tracking](https://developers.google.com/ar/develop/fundamentals#motion_tracking) capabilities. Note that this only works on devices that support ARCore; see [the official list](https://developers.google.com/ar/devices) for more information. (All devices on this list are supported, regardless of depth API support/camera resolution. Tracking accuracy may vary.)

Performance looks to be pretty good, though I am testing this on a Samsung Galaxy S23 which is pretty much a best-case scenario. The device does heat up after a while, but from what I've heard that's pretty standard for ARCore. However, as of writing, it's not stable enough yet to be actually used, which is why this PR is marked as a draft.

I'm opening this PR to get some feedback and perhaps some help with development. Here's a general TODO list:

- [ ] Add user-side toggle for enabling/disabling ARCore-based tracking (right now it's enabled by default)
- [ ] Add user-side settings for ARCore (whether to use orientation data from Cardboard or ARCore directly (not recommended unless I can work out the delay, see later comment), camera FPS limit, filtering to camera configs without depth support/with lower resolution for processing power/accuracy tradeoff, etc.)
- [ ]  **Figure out orientation drift.** The orientation (rotation) that we get from the Cardboard API drifts away from the ARCore tracking orientation over time, so e.g. walking forwards starts moving sideways instead. Using the orientation data from ARCore itself solves this, but also introduces a ~0.5s delay which is *very* noticeable. I don't think there's a way to reduce this delay - it's just a side effect of how ARCore works, and is probably going to be worse on weaker devices. The solution would likely be to somehow adjust the orientation to match the one that ARCore reports...?
  - [ ] Occasionally when ARCore loses tracking it will "teleport", i.e. the position will be shifted; I think this could be related to the repositioning behavior described in [the Pose docs](https://developers.google.com/ar/reference/java/com/google/ar/core/Pose). This completely breaks orientation when it occurs, so fixing the above would probably fix this too (in fact, I'm willing to believe that it's the same issue).
- [x] ~~**Figure out pose scaling.** Currently the actual speed of movement is a little out of wack, we will probably need to scale the values from ARCore.~~ I've done some more testing and I think it's actually fine, but someone with more VR experience would need to test.
- [x] **Figure out altitude.** Right now it seems to be wrong (~~maybe it just needs scaling? or maybe~~ it's picked up from the first plane it identifies), so you'll usually end up clipping through the floor or just generally being very low. The ARCore [geospatial API](https://developers.google.com/ar/develop/geospatial) has the ability to get altitude data, but it must use Google's location APIs which is privacy-intrusive and [has a ratelimit](https://developers.google.com/ar/develop/c/geospatial/api-usage-quota). I was also considering using the phone's barometer sensor and a short calibration process before each play session to determine the floor position and what scaling to use for anything higher than it, but I'm not sure if that's actually possible + wouldn't work on phones that don't have a barometer/pressure sensor.
  - This is done! The solution I went with is to find the lowest-placed plane and place an anchor on it; this way we can track the Y position of the floor, then subtract it from the headset position. While working on this, I also found out that ARCore's world space is based on the position of the device **when the session is set up**, so placing the device on the floor while turning on PhoneVR works best (but this also works very well once it gains tracking, so the UX is at least somewhat nice). 
  - I did have a WIP patch for barometer-based tracking, but the barometer values were *very* jittery, and to smooth them out accurately and maybe include data from other sensors for extra accuracy, I'd probably need something like a Kalman filter. Unfortunately I do not know enough maths to actually implement one, so that's left as an exercise to someone more knowledgeable than me.
  - [ ] We could probably add a setting to force a specific altitude.

I saw somebody say that iVRy supports ARCore-based tracking (personally I didn't know that, I'd have to check) - if that's true, it'd be interesting to see how they tackle some of these problems.